### PR TITLE
Fix builds with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
 
 install:
  - docker pull elementary/docker:loki
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake -DSUPPRESS_C_WARNINGS=ON . && env CTEST_OUTPUT_ON_FAILURE=true make"
  - docker pull elementary/docker:loki-unstable
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake . && env CTEST_OUTPUT_ON_FAILURE=true make"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && cmake -DSUPPRESS_C_WARNINGS=ON . && env CTEST_OUTPUT_ON_FAILURE=true make"
 
 script:
  - echo BUILDS PASSED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -551,6 +551,20 @@ set(CONSOLE_PACKAGES
 
 set(GSETTINGS_DIR ${CMAKE_SOURCE_DIR}/data)
 
+if (SUPPRESS_C_WARNINGS)
+    message(STATUS "C compiler warnings: OFF")
+
+    set(EXTRA_CFLAGS
+        ${EXTRA_CFLAGS}
+        -Wno-deprecated-declarations
+        -Wno-incompatible-pointer-types
+        -Wno-discarded-qualifiers
+    )
+    
+else ()
+    message(STATUS "C compiler warnings: ON")
+endif ()
+
 set(CFLAGS 
     ${DEPS_CFLAGS}
     ${DEPS_CFLAGS_OTHER}
@@ -562,6 +576,7 @@ set(CFLAGS
     -DLANGUAGE_SUPPORT_DIRECTORY=\"${LANGUAGE_SUPPORT_DIRECTORY}\"
     -DGCR_API_SUBJECT_TO_CHANGE
     -g
+    ${EXTRA_CFLAGS}
 )
 
 # GResource


### PR DESCRIPTION
Add cmake option SUPPRESS_C_WARNINGS.
- When enabled with cmake -DSUPPRESS_C_WARNINGS=ON .. the majority of the C compiler warnings are turned off.
- This is needed to allow builds with Travis CI, as the service limits the amount of log messages during compilation.