### PR TITLE
Ensure actions states are updated once triggered

### DIFF
--- a/src/client/composer/composer-widget.vala
+++ b/src/client/composer/composer-widget.vala
@@ -1637,6 +1637,7 @@ public class ComposerWidget : Gtk.EventBox {
         string[] prefixed_action_name = action.get_name ().split (".");
         string action_name = prefixed_action_name[prefixed_action_name.length - 1];
         this.editor.get_dom_document ().exec_command (action_name, false, "");
+        update_actions ();
     }
     
     private void on_cut() {


### PR DESCRIPTION
This fixes a regression I've noticed after the previous commit.

Before this commit, in the composer, if you use one of the shortcuts for the toggleable actions (like Ctrl+B for Bold). The related button in the toolbar doesn't toggle its state until you start typing.

This branch resolves this.