### PR TITLE
Move CSS to an external stylesheet

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -1,0 +1,7 @@
+.conversation-list-item {
+    box-shadow: 0 -1px 0 @menu_separator;
+}
+
+.unread-message {
+    font-weight: bolder;
+}

--- a/data/io.elementary.mail.gresource.xml
+++ b/data/io.elementary.mail.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/mail">
+    <file alias="application.css" compressed="true">application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,12 @@ dependencies = [
     webkit2_dep
 ]
 
+asresources = gnome.compile_resources(
+    'as-resources', 'data/' + meson.project_name() + '.gresource.xml',
+    source_dir: 'data',
+    c_name: 'as'
+)
+
 extension_dependencies = [
     glib_dep,
     gobject_dep,

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -57,6 +57,10 @@ public class Mail.Application : Gtk.Application {
             main_window.show_all ();
             add_window (main_window);
 
+            var css_provider = new Gtk.CssProvider ();
+            css_provider.load_from_resource ("io/elementary/mail/application.css");
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
             main_window.state_changed.connect (() => {
                 int root_x, root_y;
                 main_window.get_position (out root_x, out root_y);

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -21,16 +21,6 @@
  */
 
 public class Mail.ConversationListItem : Gtk.ListBoxRow {
-    private const string UNREAD_MESSAGE_CLASS_CSS = """
-        .conversation-list-item {
-            box-shadow: 0 -1px 0 @menu_separator;
-        }
-
-        .unread-message {
-            font-weight: bolder;
-        }
-    """;
-
     public Camel.FolderThreadNode node { get; private set; }
 
     Gtk.Label source;
@@ -92,14 +82,6 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
 
         get_style_context ().add_class ("conversation-list-item");
         add (grid);
-
-        var css_provider = new Gtk.CssProvider ();
-        try {
-            css_provider.load_from_data (UNREAD_MESSAGE_CLASS_CSS);
-            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        } catch (Error e) {
-            critical (e.message);
-        }
 
         show_all ();
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ vala_files = [
 
 executable('io.elementary.mail',
     vala_files,
+    asresources,
     dependencies: dependencies,
     c_args: '-DWEBKIT_EXTENSION_PATH="' + webkit2_extension_path + '"'
 )


### PR DESCRIPTION
This adds a gresource and moves CSS out of the ConversationListItem into an application css stylesheet. This should prevent creating multiple style providers inside the application later on and making sure there's a centralized place to view all application CSS styles.