### PR TITLE
Display relative date time in conversation list

### DIFF
--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -144,9 +144,9 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
             return date_time.format ("%a");
         }
         if (date_time.get_year () == now.get_year ()) {
-            return date_time.format ("%b %e");
+            return date_time.format ("%b %-e");
         }
-        return date_time.format ("%b %e %Y");
+        return date_time.format ("%x");
     }
 
     private bool is_same_day (DateTime day1, DateTime day2) {

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -122,31 +122,25 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
         if (is_same_day (date_time, now)) {
             if (diff < TimeSpan.MINUTE) {
                 return _("Now");
-            }
-            if (diff < TimeSpan.HOUR) {
-                return ngettext ("%dm ago", "%dm ago", (ulong) (diff / TimeSpan.MINUTE)).printf ((int) (diff / TimeSpan.MINUTE));
-            }
-            if (diff < 12 * TimeSpan.HOUR) {
+            } else if (diff < TimeSpan.HOUR) {
+                var minutes = diff / TimeSpan.MINUTE;
+                return ngettext ("%dm ago", "%dm ago", (ulong) (minutes)).printf ((int) (minutes));
+            } else if (diff < 12 * TimeSpan.HOUR) {
                 int rounded = (int) Math.round ((double) diff / TimeSpan.HOUR);
                 return ngettext ("%dh ago", "%dh ago", (ulong) rounded).printf (rounded);
-            }
-            var settings = new Settings ("org.gnome.desktop.interface");
-            if (settings.get_enum ("clock-format") == 0) {
-                return date_time.format ("%H:%M");
             } else {
-                return date_time.format ("%l:%M %p");
+                var settings = new Settings ("org.gnome.desktop.interface");
+                return Granite.DateTime.get_default_time_format (settings.get_enum ("clock-format") == 1, false);
             }
-        }
-        if (is_same_day (date_time.add_days (1), now)) {
+        } else if (is_same_day (date_time.add_days (1), now)) {
             return _("Yesterday");
-        }
-        if (diff < 6 * TimeSpan.DAY) {
+        } else if (diff < 6 * TimeSpan.DAY) {
             return date_time.format ("%a");
+        } else if (date_time.get_year () == now.get_year ()) {
+            return date_time.format (_("%b %-e"));
+        } else {
+            return date_time.format ("%x");
         }
-        if (date_time.get_year () == now.get_year ()) {
-            return date_time.format ("%b %-e");
-        }
-        return date_time.format ("%x");
     }
 
     private bool is_same_day (DateTime day1, DateTime day2) {

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -54,7 +54,7 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
             flagged_icon_revealer.reveal_child = true;
         }
 
-        date.label = new DateTime.from_unix_utc (node.message.date_received).format ("%b %e");
+        date.label = get_relative_datetime (new DateTime.from_unix_local (node.message.date_received));
     }
 
     construct {
@@ -113,5 +113,27 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
         }
 
         return i;
+    }
+
+    private string get_relative_datetime (DateTime date_time) {
+        var now = new DateTime.now_local ();
+
+        if (is_same_day (date_time, now)) {
+            return date_time.format ("%l:%M %p");
+        }
+        if (is_same_day (date_time.add_days (1), now)) {
+            return _("Yesterday");
+        }
+        if (date_time.get_year () == now.get_year ()) {
+            return date_time.format ("%b %e");
+        }
+        return date_time.format ("%b %e %Y");
+    }
+
+    private bool is_same_day (DateTime day1, DateTime day2) {
+        if (day1.get_day_of_year () == day2.get_day_of_year () && day1.get_year () == day2.get_year ()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -117,12 +117,26 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
 
     private string get_relative_datetime (DateTime date_time) {
         var now = new DateTime.now_local ();
+        var diff = now.difference (date_time);
 
         if (is_same_day (date_time, now)) {
+            if (diff < TimeSpan.MINUTE) {
+                return _("Now");
+            }
+            if (diff < TimeSpan.HOUR) {
+                return ngettext("%dm ago", "%dm ago", (ulong) (diff / TimeSpan.MINUTE)).printf((int) (diff / TimeSpan.MINUTE));
+            }
+            if (diff < 12 * TimeSpan.HOUR) {
+                int rounded = (int) Math.round((double) diff / TimeSpan.HOUR);
+                return ngettext("%dh ago", "%dh ago", (ulong) rounded).printf(rounded);
+            }
             return date_time.format ("%l:%M %p");
         }
         if (is_same_day (date_time.add_days (1), now)) {
             return _("Yesterday");
+        }
+        if (diff < 6 * TimeSpan.DAY) {
+            return date_time.format ("%a");
         }
         if (date_time.get_year () == now.get_year ()) {
             return date_time.format ("%b %e");

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -124,11 +124,11 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
                 return _("Now");
             }
             if (diff < TimeSpan.HOUR) {
-                return ngettext("%dm ago", "%dm ago", (ulong) (diff / TimeSpan.MINUTE)).printf((int) (diff / TimeSpan.MINUTE));
+                return ngettext ("%dm ago", "%dm ago", (ulong) (diff / TimeSpan.MINUTE)).printf ((int) (diff / TimeSpan.MINUTE));
             }
             if (diff < 12 * TimeSpan.HOUR) {
-                int rounded = (int) Math.round((double) diff / TimeSpan.HOUR);
-                return ngettext("%dh ago", "%dh ago", (ulong) rounded).printf(rounded);
+                int rounded = (int) Math.round ((double) diff / TimeSpan.HOUR);
+                return ngettext ("%dh ago", "%dh ago", (ulong) rounded).printf (rounded);
             }
             var settings = new Settings ("org.gnome.desktop.interface");
             if (settings.get_enum ("clock-format") == 0) {

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -130,7 +130,12 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
                 int rounded = (int) Math.round((double) diff / TimeSpan.HOUR);
                 return ngettext("%dh ago", "%dh ago", (ulong) rounded).printf(rounded);
             }
-            return date_time.format ("%l:%M %p");
+            var settings = new Settings ("org.gnome.desktop.interface");
+            if (settings.get_enum ("clock-format") == 0) {
+                return date_time.format ("%H:%M");
+            } else {
+                return date_time.format ("%l:%M %p");
+            }
         }
         if (is_same_day (date_time.add_days (1), now)) {
             return _("Yesterday");

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,5 +19,6 @@ executable('io.elementary.mail',
     asresources,
     dependencies: dependencies,
     c_args: '-DWEBKIT_EXTENSION_PATH="' + webkit2_extension_path + '"',
+    link_args : '-lm',
     install: true
 )


### PR DESCRIPTION
This duplicates the functionality from https://github.com/elementary/mail/blob/master/src/client/util/util-date.vala

Show messages received:
- [x] Less than a minute ago as "Now"
- [x] Less than an hour ago as "5m ago"
- [x] Today, Less than 12 hours ago as "1h ago"
- [x] All other times Today as "10:04 AM"
    - [x] With localized 12/24 hours
- [x] Yesterday as "Yesterday"
- [x] Less than a week ago as "Sat"
- [x] This year as "Jun 15"
- [x] All other times as "nn/nn/nn", localized