### PR TITLE
Pass Camel.Folder through to MessageListItem

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -67,8 +67,8 @@ public class Mail.MainWindow : Gtk.Window {
             conversation_list_box.set_folder.begin (account, folder_name);
         });
 
-        conversation_list_box.conversation_selected.connect ((node) => {
-            message_list_box.set_conversation (node);
+        conversation_list_box.conversation_selected.connect ((node, folder) => {
+            message_list_box.set_conversation (node, folder);
         });
 
         Backend.Session.get_default ().start.begin ();

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -19,16 +19,20 @@
  */
 
 public class Mail.MessageListBox : Gtk.ListBox {
+    private Camel.Folder? folder;
+
     construct {
         get_style_context ().add_class ("deck");
     }
 
-    public void set_conversation (Camel.FolderThreadNode node) {
+    public void set_conversation (Camel.FolderThreadNode node, Camel.Folder? folder) {
+        this.folder = folder;
+
         get_children ().foreach ((child) => {
             child.destroy ();
         });
 
-        var item = new MessageListItem (node.message);
+        var item = new MessageListItem (node.message, folder);
         add (item);
         if (node.child != null) {
             go_down ((Camel.FolderThreadNode?) node.child);
@@ -38,7 +42,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
     private void go_down (Camel.FolderThreadNode node) {
         unowned Camel.FolderThreadNode? current_node = node;
         while (current_node != null) {
-            var item = new MessageListItem (current_node.message);
+            var item = new MessageListItem (current_node.message, folder);
             add (item);
             if (current_node.next != null) {
                 go_down ((Camel.FolderThreadNode?) current_node.next);

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -20,9 +20,10 @@
 
 public class Mail.MessageListItem : Gtk.ListBoxRow {
     public Camel.MessageInfo message_info { get; construct; }
+    public Camel.Folder? folder { get; construct; }
 
-    public MessageListItem (Camel.MessageInfo message_info) {
-        Object (message_info: message_info);
+    public MessageListItem (Camel.MessageInfo message_info, Camel.Folder? folder) {
+        Object (message_info: message_info, folder: folder);
     }
 
     construct {
@@ -70,6 +71,12 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
         var web_view = new Mail.WebView ();
         web_view.margin = 6;
+
+        if (folder != null) {
+            var message = folder.get_message_sync (message_info.uid);
+            // We can now get mime parts of the message
+            // TODO: Parse message and display in webview
+        }
 
         var base_grid = new Gtk.Grid ();
         base_grid.expand = true;


### PR DESCRIPTION
In order to get the content of an individual message, it seems we need a reference to the folder it came from. Pass the folder reference through so we can get ready to parse the message and display in the WebView.