### PR TITLE
Load inline images

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -164,6 +164,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
                 warning ("Possible error decoding email message: %s", e.message);
                 return;
             }
+
             message_content = (string) os.steal_data ();
             if (field.subtype == "html") {
                 message_is_html = true;
@@ -181,6 +182,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             warning ("Error decoding inline attachment: %s", e.message);
             return;
         }
+
         Bytes bytes;
         bytes = ByteArray.free_to_bytes (byte_array);
         var inline_stream = new MemoryInputStream.from_bytes (bytes);

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -188,15 +188,4 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         var inline_stream = new MemoryInputStream.from_bytes (bytes);
         web_view.add_internal_resource (part.get_content_id (), inline_stream);
     }
-
-    public static int get_content_type_priority (string mime_type) {
-        switch (mime_type) {
-            case "text/plain":
-                return 1;
-            case "text/html":
-                return 2;
-            default:
-                return 0;
-        }
-    }
 }

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -23,6 +23,8 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
     private Mail.WebView web_view;
     private GLib.Cancellable loading_cancellable;
+    private string message_content;
+    private bool message_is_html = false;
 
     public MessageListItem (Camel.MessageInfo message_info) {
         Object (
@@ -121,52 +123,58 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         var folder = message_info.summary.folder;
         try {
             message = yield folder.get_message (message_info.uid, GLib.Priority.DEFAULT, loading_cancellable);
-            bool is_html;
-            var content = yield get_mime_content (message.content, out is_html);
-            if (is_html) {
-                web_view.load_html (content, null);
+            yield parse_mime_content (message.content);
+            if (message_is_html) {
+                web_view.load_html (message_content, null);
             } else {
-                web_view.load_plain_text (content);
+                web_view.load_plain_text (message_content);
             }
         } catch (Error e) {
             debug("Could not get message. %s", e.message);
         }
     }
 
-    private async string get_mime_content (Camel.DataWrapper message_content, out bool is_html) {
-        Camel.DataWrapper data_container = message_content;
-        if (data_container is Camel.Multipart) {
-            var content = data_container as Camel.Multipart;
-            int content_priority = 0;
+    private async void parse_mime_content (Camel.DataWrapper message_content) {
+        if (message_content is Camel.Multipart) {
+            var content = message_content as Camel.Multipart;
             for (uint i = 0; i < content.get_number (); i++) {
                 var part = content.get_part (i);
-                if (part.get_mime_type_field ().type == "multipart") {
-                    return yield get_mime_content (part.content, out is_html);
-                }
-                int current_content_priority = get_content_type_priority (part.get_mime_type ());
-                if (current_content_priority > content_priority) {
-                    data_container = part.content;
+                var field = part.get_mime_type_field ();
+                if (part.disposition == "inline") {
+                    yield handle_inline_mime (part);
+                } else if (field.type == "text") {
+                    yield handle_text_mime (part.content);
+                } else if (field.type == "multipart") {
+                    yield parse_mime_content (part.content);
                 }
             }
+        } else {
+            yield handle_text_mime (message_content);
         }
+    }
 
-        string current_content;
-        try {
-            var field = data_container.get_mime_type_field ();
-            debug ("%s", field.simple ());
-
+    private async void handle_text_mime (Camel.DataWrapper part) {
+        var field = part.get_mime_type_field ();
+        if (message_content == null || (!message_is_html && field.subtype == "html")) {
             var os = new GLib.MemoryOutputStream.resizable ();
-            yield data_container.decode_to_output_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
+            yield part.decode_to_output_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
             os.close ();
-            current_content = (string) os.steal_data ();
-            
-            is_html = field.subtype == "html";
-        } catch (Error e) {
-            current_content = "Error loading the message: %s".printf (e.message);
-            is_html = false;
+            message_content = (string) os.steal_data ();
+            if (field.subtype == "html") {
+                message_is_html = true;
+            }
         }
+    }
 
-        return current_content;
+    private async void handle_inline_mime (Camel.MimePart part) {
+        var byte_array = new ByteArray ();
+        var os = new Camel.StreamMem ();
+        os.set_byte_array (byte_array);
+        yield part.content.decode_to_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
+        Bytes bytes;
+        bytes = ByteArray.free_to_bytes (byte_array);
+        var inline_stream = new MemoryInputStream.from_bytes (bytes);
+        web_view.add_internal_resource (part.get_content_id (), inline_stream);
     }
 
     public static int get_content_type_priority (string mime_type) {

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -81,6 +81,7 @@ public class Mail.WebView : WebKit.WebView {
             request.finish (buf, -1, null);
             return true;
         }
+
         return false;
     }
 }

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -33,7 +33,7 @@ public class Mail.WebView : WebKit.WebView {
         context.register_uri_scheme ("cid", (req) => {
             WebView? view = req.get_web_view () as WebView;
             if (view != null) {
-                view.handle_cid_request(req);
+                view.handle_cid_request (req);
             }
         });
     }

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Corentin Noël <corentin@elementary.io>
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
  */
 
 public extern const string WEBKIT_EXTENSION_PATH;
@@ -23,15 +23,25 @@ public extern const string WEBKIT_EXTENSION_PATH;
 public class Mail.WebView : WebKit.WebView {
     private int preferred_height = 0;
     private WebViewServer view_manager;
+    private Gee.Map<string, InputStream> internal_resources;
 
     static construct {
         weak WebKit.WebContext context = WebKit.WebContext.get_default ();
         unowned string? webkit_extension_path_env = Environment.get_variable ("WEBKIT_EXTENSION_PATH");
         context.set_web_extensions_directory (webkit_extension_path_env ?? WEBKIT_EXTENSION_PATH);
+
+        context.register_uri_scheme ("cid", (req) => {
+            WebView? view = req.get_web_view () as WebView;
+            if (view != null) {
+                view.handle_cid_request(req);
+            }
+        });
     }
 
     construct {
         expand = true;
+
+        internal_resources = new Gee.HashMap<string, InputStream> ();
 
         view_manager = WebViewServer.get_default ();
         view_manager.page_height_updated.connect ((page_id) => {
@@ -52,5 +62,25 @@ public class Mail.WebView : WebKit.WebView {
 
     public override void get_preferred_height (out int minimum_height, out int natural_height) {
         minimum_height = natural_height = preferred_height;
+    }
+
+    public void add_internal_resource (string name, InputStream data) {
+        internal_resources[name] = data;
+    }
+
+    private void handle_cid_request (WebKit.URISchemeRequest request) {
+        if (!handle_internal_response (request)) {
+            request.finish_error (new FileError.NOENT ("Unknown CID"));
+        }
+    }
+
+    private bool handle_internal_response (WebKit.URISchemeRequest request) {
+        string name = Soup.URI.decode (request.get_path ());
+        InputStream? buf = this.internal_resources[name];
+        if (buf != null) {
+            request.finish (buf, -1, null);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Ensure we pull any mime parts out of the message that are marked as `inline`. This allows us to display attachments inline in the WebView as well as the ones that are loaded from web URLs.