### PR TITLE
Remote image blocking

### DIFF
--- a/data/io.elementary.mail.gschema.xml
+++ b/data/io.elementary.mail.gschema.xml
@@ -33,6 +33,16 @@
       <summary>Most recent position of the conversation list pane</summary>
       <description>Most recent position of the conversation list pane</description>
     </key>
+    <key name="always-load-remote-images" type="b">
+      <default>true</default>
+      <summary>Whether to always load remote images without prompting</summary>
+      <description>Whether to always load remote images without prompting</description>
+    </key>
+    <key name="remote-images-whitelist" type="as">
+      <default>[]</default>
+      <summary>A list of sender addresses for which remote images will be automatically loaded</summary>
+      <description>A list of sender addresses for which remote images will be automatically loaded</description>
+    </key>
   </schema>
 </schemalist>
 

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -21,6 +21,8 @@
 public extern const string WEBKIT_EXTENSION_PATH;
 
 public class Mail.WebView : WebKit.WebView {
+    public signal void image_load_blocked ();
+
     private int preferred_height = 0;
     private WebViewServer view_manager;
     private Gee.Map<string, InputStream> internal_resources;
@@ -50,6 +52,11 @@ public class Mail.WebView : WebKit.WebView {
                 queue_resize ();
             }
         });
+        view_manager.image_load_blocked.connect ((page_id) => {
+            if (page_id == get_page_id ()) {
+                image_load_blocked ();
+            }
+        });
 
         load_changed.connect (on_load_changed);
     }
@@ -66,6 +73,10 @@ public class Mail.WebView : WebKit.WebView {
 
     public void add_internal_resource (string name, InputStream data) {
         internal_resources[name] = data;
+    }
+
+    public void load_images () {
+        view_manager.set_load_images (get_page_id (), true);
     }
 
     private void handle_cid_request (WebKit.URISchemeRequest request) {

--- a/src/WebViewServer.vala
+++ b/src/WebViewServer.vala
@@ -23,9 +23,15 @@ public class Mail.WebViewServer : GLib.Object {
     private static WebViewServer? _instance = null;
     private Gee.HashMap <uint64?, int> view_heights
         = new Gee.HashMap <uint64?, int> ((Gee.HashDataFunc)int64_hash, (Gee.EqualDataFunc)int64_equal);
+    private Gee.HashMap <uint64?, bool> show_images
+        = new Gee.HashMap <uint64?, bool> ((Gee.HashDataFunc)int64_hash, (Gee.EqualDataFunc)int64_equal);
 
     public signal void page_load_changed (uint64 page_id);
-    
+    public signal void image_loading_enabled (uint64 page_id);
+
+    [DBus (visible = false)]
+    public signal void image_load_blocked (uint64 page_id);
+
     [DBus (visible = false)]
     public signal void page_height_updated (uint64 page_id);
 
@@ -47,6 +53,26 @@ public class Mail.WebViewServer : GLib.Object {
         }
         view_heights [view] = height;
         page_height_updated (view);
+    }
+
+    [DBus (visible = false)]
+    public void set_load_images (uint64 view, bool load_images) {
+        show_images [view] = load_images;
+        if (load_images == true) {
+            image_loading_enabled (view);
+        }
+    }
+
+    public bool get_load_images (uint64 view) {
+        if (show_images.has_key (view)) {
+            return show_images [view];
+        } else {
+            return false;
+        }
+    }
+
+    public void fire_image_load_blocked (uint64 view) {
+        image_load_blocked (view);
     }
 
     [DBus (visible = false)]


### PR DESCRIPTION
Add two settings keys, one to always allow image loading (defaults to true), another as an email address whitelist of  sender addresses for which remote images will be automatically loaded.

I've not added any UI for controlling the settings keys, nor have I added the infobar that will show when images are blocked (though I have left a TODO comment on the signal where that would be).