### PR TITLE
Open attachment dialog fixes

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -7,6 +7,7 @@ src/Backend/Account.vala
 src/Backend/Session.vala
 src/ConversationList/ConversationListBox.vala
 src/ConversationList/ConversationListItem.vala
+src/Dialogs/OpenAttachmentDialog.vala
 src/FoldersView/AccountSourceItem.vala
 src/FoldersView/FoldersListView.vala
 src/FoldersView/FolderSourceItem.vala
@@ -14,4 +15,3 @@ src/MessageList/MessageListBox.vala
 src/MessageList/MessageListItem.vala
 src/MessageList/AttachmentBar.vala
 src/MessageList/AttachmentButton.vala
-src/MessageList/AttachmentDialog.vala

--- a/src/Dialogs/OpenAttachmentDialog.vala
+++ b/src/Dialogs/OpenAttachmentDialog.vala
@@ -21,11 +21,12 @@
 public class Mail.OpenAttachmentDialog : Gtk.Dialog {
     public Camel.MimePart mime_part { get; construct; }
 
-    public OpenAttachmentDialog (Camel.MimePart mime_part) {
+    public OpenAttachmentDialog (Gtk.Window parent, Camel.MimePart mime_part) {
         Object (
             deletable: false,
             mime_part: mime_part,
-            resizable: false
+            resizable: false,
+            transient_for: parent
         );
     }
 
@@ -68,8 +69,6 @@ public class Mail.OpenAttachmentDialog : Gtk.Dialog {
                 show_file_anyway.begin ();
             }
         });
-
-        show_all ();
     }
 
     private async void show_file_anyway () {

--- a/src/Dialogs/OpenAttachmentDialog.vala
+++ b/src/Dialogs/OpenAttachmentDialog.vala
@@ -76,7 +76,7 @@ public class Mail.OpenAttachmentDialog : Gtk.Dialog {
             GLib.FileIOStream iostream;
             var file = File.new_tmp ("XXXXXX-%s".printf (mime_part.get_filename ()), out iostream);
             yield mime_part.content.decode_to_output_stream (iostream.output_stream, GLib.Priority.DEFAULT, null);
-            yield GLib.AppInfo.launch_default_for_uri_async (file.get_uri (), new AppLaunchContext (), null);
+            yield GLib.AppInfo.launch_default_for_uri_async (file.get_uri (), (AppLaunchContext) null, null);
         } catch (Error e) {
             critical (e.message);
         }

--- a/src/Dialogs/OpenAttachmentDialog.vala
+++ b/src/Dialogs/OpenAttachmentDialog.vala
@@ -76,7 +76,7 @@ public class Mail.OpenAttachmentDialog : Gtk.Dialog {
             GLib.FileIOStream iostream;
             var file = File.new_tmp ("XXXXXX-%s".printf (mime_part.get_filename ()), out iostream);
             yield mime_part.content.decode_to_output_stream (iostream.output_stream, GLib.Priority.DEFAULT, null);
-            yield GLib.AppInfo.launch_default_for_uri_async (file.get_uri (), null, null);
+            yield GLib.AppInfo.launch_default_for_uri_async (file.get_uri (), new AppLaunchContext (), null);
         } catch (Error e) {
             critical (e.message);
         }

--- a/src/Dialogs/OpenAttachmentDialog.vala
+++ b/src/Dialogs/OpenAttachmentDialog.vala
@@ -18,11 +18,15 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Mail.AttachmentDialog : Gtk.Dialog {
+public class Mail.OpenAttachmentDialog : Gtk.Dialog {
     public Camel.MimePart mime_part { get; construct; }
 
-    public AttachmentDialog (Camel.MimePart mime_part) {
-        Object (mime_part: mime_part);
+    public OpenAttachmentDialog (Camel.MimePart mime_part) {
+        Object (
+            deletable: false,
+            mime_part: mime_part,
+            resizable: false
+        );
     }
 
     construct {
@@ -34,6 +38,7 @@ public class Mail.AttachmentDialog : Gtk.Dialog {
         primary_label.max_width_chars = 60;
         primary_label.wrap = true;
         primary_label.xalign = 0;
+        primary_label.get_style_context ().add_class ("primary");
 
         var secondary_label = new Gtk.Label (_("Attachments may cause damage to your system if opened. Only open files from trusted sources."));
         secondary_label.max_width_chars = 60;
@@ -44,15 +49,17 @@ public class Mail.AttachmentDialog : Gtk.Dialog {
         open_button.get_style_context ().add_class ("destructive-action");
 
         var layout = new Gtk.Grid ();
-        layout.margin = 6;
+        layout.margin = 12;
+        layout.margin_top = 0;
         layout.column_spacing = 12;
         layout.row_spacing = 6;
         layout.attach (warning_image, 0, 0, 1, 2);
         layout.attach (primary_label, 1, 0, 1, 1);
         layout.attach (secondary_label, 1, 1, 1, 1);
 
-        var content = get_content_area () as Gtk.Box;
-        content.add (layout);
+        ((Gtk.Box) get_content_area ()).add (layout);
+
+        ((Gtk.Box) get_action_area ()).margin = 5;
 
         add_button (_("Cancel"), Gtk.ResponseType.CLOSE);
         add_action_widget (open_button, Gtk.ResponseType.OK);

--- a/src/MessageList/AttachmentBar.vala
+++ b/src/MessageList/AttachmentBar.vala
@@ -69,7 +69,7 @@ public class Mail.AttachmentBar : Gtk.FlowBox {
     }
 
     private void show_attachment (Camel.MimePart attachment_part) {
-        var dialog = new Mail.AttachmentDialog (attachment_part);
+        var dialog = new Mail.OpenAttachmentDialog (attachment_part);
         dialog.transient_for = get_toplevel () as Gtk.Window;
         dialog.run ();
         dialog.destroy ();

--- a/src/MessageList/AttachmentBar.vala
+++ b/src/MessageList/AttachmentBar.vala
@@ -69,7 +69,7 @@ public class Mail.AttachmentBar : Gtk.FlowBox {
     }
 
     private void show_attachment (Camel.MimePart attachment_part) {
-        var dialog = new Mail.OpenAttachmentDialog ((Gtk.Window) get_toplevel (), attachment_part);
+        var dialog = new Mail.OpenAttachmentDialog (get_toplevel () as Gtk.Window, attachment_part);
         dialog.show_all ();
         dialog.run ();
         dialog.destroy ();

--- a/src/MessageList/AttachmentBar.vala
+++ b/src/MessageList/AttachmentBar.vala
@@ -69,8 +69,8 @@ public class Mail.AttachmentBar : Gtk.FlowBox {
     }
 
     private void show_attachment (Camel.MimePart attachment_part) {
-        var dialog = new Mail.OpenAttachmentDialog (attachment_part);
-        dialog.transient_for = get_toplevel () as Gtk.Window;
+        var dialog = new Mail.OpenAttachmentDialog ((Gtk.Window) get_toplevel (), attachment_part);
+        dialog.show_all ();
         dialog.run ();
         dialog.destroy ();
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ vala_files = [
     'Application.vala',
     'MainWindow.vala',
     'HeaderBar.vala',
+    'Dialogs/OpenAttachmentDialog.vala',
     'WebView.vala',
     'WebViewServer.vala',
     'Backend/Session.vala',
@@ -14,8 +15,7 @@ vala_files = [
     'MessageList/MessageListBox.vala',
     'MessageList/MessageListItem.vala',
     'MessageList/AttachmentBar.vala',
-    'MessageList/AttachmentButton.vala',
-    'MessageList/AttachmentDialog.vala'
+    'MessageList/AttachmentButton.vala'
 ]
 
 executable('io.elementary.mail',


### PR DESCRIPTION
* Rename to resolve ambiguity with future FileDialog subclass
* Move to `Dialogs` as in other elementary apps
* Fix styling, sizing
* Resolve terminal warnings about no transient parent, etc