### PR TITLE
Prevent ScrolledWindow scrolling to the top when webview is focused

### DIFF
--- a/src/client/conversation-viewer/conversation-viewer.vala
+++ b/src/client/conversation-viewer/conversation-viewer.vala
@@ -187,6 +187,9 @@ public class ConversationViewer : Gtk.Stack {
         conversation_scrolled.size_allocate.connect(mark_read);
         conversation_scrolled.vadjustment.value_changed.connect(mark_read);
         conversation_scrolled.vadjustment.changed.connect(display_last_email);
+        // Prevent the focus of the webview causing the ScrolledWindow to scroll
+        var viewport = conversation_scrolled.get_child () as Gtk.Container;
+        viewport.set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
         
         // Stops button_press_event
         conversation_list_box.button_press_event.connect ((b) => {            

--- a/src/client/conversation-viewer/conversation-viewer.vala
+++ b/src/client/conversation-viewer/conversation-viewer.vala
@@ -188,8 +188,10 @@ public class ConversationViewer : Gtk.Stack {
         conversation_scrolled.vadjustment.value_changed.connect(mark_read);
         conversation_scrolled.vadjustment.changed.connect(display_last_email);
         // Prevent the focus of the webview causing the ScrolledWindow to scroll
-        var viewport = conversation_scrolled.get_child () as Gtk.Container;
-        viewport.set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
+        var scrolled_child = conversation_scrolled.get_child ();
+        if (scrolled_child is Gtk.Container) {
+            ((Gtk.Container) scrolled_child).set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
+        }
         
         // Stops button_press_event
         conversation_list_box.button_press_event.connect ((b) => {            


### PR DESCRIPTION
Fixes #6 .

