### PR TITLE
Add a missing allowed scheme

### DIFF
--- a/webkit-extension/Main.vala
+++ b/webkit-extension/Main.vala
@@ -31,7 +31,7 @@ namespace MailWebViewExtension {
 }
 
 public class DOMServer : Object {
-    private const string[] ALLOWED_SCHEMES = { "cid", "data", "about" };
+    private const string[] ALLOWED_SCHEMES = { "cid", "data", "about", "elementary-mail" };
 
     private WebKit.WebExtension extension;
 


### PR DESCRIPTION
This would have been throwing up some blocked image infobars on emails that didn't have images.