### PR TITLE
Add preferences menu

### DIFF
--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -29,7 +29,52 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         compose_button.action_name = "win." + MainWindow.ACTION_COMPOSE_MESSAGE;
 
         var search_entry = new Gtk.SearchEntry ();
+
+        var load_images_switch = new Gtk.Switch ();
+
+        var load_images_grid = new Gtk.Grid ();
+        load_images_grid.column_spacing = 6;
+        load_images_grid.margin_end = 6;
+        load_images_grid.margin_start = 3;
+        load_images_grid.add (new Gtk.Label (_("Always Show Remote Images")));
+        load_images_grid.add (load_images_switch);
+
+        var load_images_menuitem = new Gtk.Button ();
+        load_images_menuitem.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+        load_images_menuitem.add (load_images_grid);
+
+        var account_settings_menuitem = new Gtk.ModelButton ();
+        account_settings_menuitem.text = _("Account Settings…");
+
+        var app_menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+        app_menu_separator.margin_bottom = 3;
+        app_menu_separator.margin_top = 3;
+
+        var app_menu_grid = new Gtk.Grid ();
+        app_menu_grid.margin_bottom = 3;
+        app_menu_grid.margin_top = 3;
+        app_menu_grid.orientation = Gtk.Orientation.VERTICAL;
+        app_menu_grid.add (load_images_menuitem);
+        app_menu_grid.add (app_menu_separator);
+        app_menu_grid.add (account_settings_menuitem);
+        app_menu_grid.show_all ();
+
+        var app_menu = new Gtk.MenuButton ();
+        var app_menu_popover = new Gtk.Popover (app_menu);
+        app_menu_popover.add (app_menu_grid);
+        app_menu.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
+        app_menu.popover = app_menu_popover;
+
         pack_start (compose_button);
+        pack_end (app_menu);
         pack_end (search_entry);
+
+        account_settings_menuitem.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+            } catch (Error e) {
+                warning ("Failed to open account settings: %s", e.message);
+            }     
+        });
     }
 }

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -41,10 +41,13 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
 
         var load_images_switch = new Gtk.Switch ();
 
+        var settings = new GLib.Settings ("io.elementary.mail");
+        settings.bind ("always-load-remote-images", load_images_switch, "active", SettingsBindFlags.DEFAULT);
+
         var load_images_grid = new Gtk.Grid ();
-        load_images_grid.column_spacing = 6;
+        load_images_grid.column_spacing = 12;
         load_images_grid.margin_end = 6;
-        load_images_grid.margin_start = 3;
+        load_images_grid.margin_start = 6;
         load_images_grid.add (new Gtk.Label (_("Always Show Remote Images")));
         load_images_grid.add (load_images_switch);
 
@@ -84,6 +87,10 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
             } catch (Error e) {
                 warning ("Failed to open account settings: %s", e.message);
             }     
+        });
+
+        load_images_menuitem.clicked.connect (() => {
+            load_images_switch.activate ();
         });
     }
 }

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -76,6 +76,7 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         app_menu_popover.add (app_menu_grid);
         app_menu.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
         app_menu.popover = app_menu_popover;
+        app_menu.tooltip_text = _("Menu");
 
         pack_start (paned_start_grid);
         pack_start (search_entry);


### PR DESCRIPTION
Depends on https://github.com/elementary/stylesheet/pull/153 to be styled correctly

![screenshot from 2017-07-22 11 32 49](https://user-images.githubusercontent.com/7277719/28493789-8309a6f8-6ed1-11e7-8fe3-3b57eba29d28.png)

There's only one real preference at this time, so no dialog. If/when there are more preferences we can do a dialog, but if there's only a couple settings this is just faster and easier, imo. If we end up having more of these switch menu items, I'll refactor that into a widget class

Account settings are all external, so assume that the system online accounts settings knows what to do.