### PR TITLE
improve the offset calculation

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -128,17 +128,18 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
     }
     
     private void update_paned_start_grid_width () {
-        int offset = 0;
+        var style_context = headerbar.get_style_context ();
+        var padding = style_context.get_padding (style_context.get_state ());
+
+        int offset = padding.left;
         headerbar.forall ((widget) => {
             if (widget.get_style_context ().has_class ("left")) {
-                offset = widget.get_allocated_width ();
+                offset += widget.get_allocated_width ();
+                offset += headerbar.spacing;
                 return;
             }
         });
-
-        var style_context = headerbar.get_style_context ();
-        var padding = style_context.get_padding (style_context.get_state ());
-        offset += headerbar.spacing + padding.left + padding.right;
+        offset += headerbar.spacing;
 
         headerbar.paned_start_grid.width_request = paned_start.position - offset;
     }


### PR DESCRIPTION
See https://github.com/elementary/mail/pull/77#issuecomment-317276078 for an explanation.

You should be able to test this by running
`gsettings set org.gnome.desktop.wm.preferences button-layout :close`

Also, the offset is now calculated from left to right by first adding the padding.