### PR TITLE
Add attention class to unread icon

### DIFF
--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -59,6 +59,7 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
 
     construct {
         var unread_icon = new Gtk.Image.from_icon_name ("mail-unread-symbolic", Gtk.IconSize.MENU);
+        unread_icon.get_style_context ().add_class ("attention");
         unread_icon_revealer = new Gtk.Revealer ();
         unread_icon_revealer.add (unread_icon);
 


### PR DESCRIPTION
It looks like `-gtk-icon-palette` doesn't allow custom variables, so we can cheat and use a style class:

![screenshot from 2017-07-25 20 49 46](https://user-images.githubusercontent.com/7277719/28603766-00b80cb0-717b-11e7-8d5b-0c49678521c1.png)

Requires this branch: https://github.com/elementary/stylesheet/pull/163