### PR TITLE
Move re-usable parts of composer into separate widget

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -6,6 +6,7 @@ src/WebViewServer.vala
 src/Backend/Account.vala
 src/Backend/Session.vala
 src/Composer/ComposerWindow.vala
+src/Composer/ComposerWidget.vala
 src/ConversationList/ConversationListBox.vala
 src/ConversationList/ConversationListItem.vala
 src/Dialogs/OpenAttachmentDialog.vala

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -1,0 +1,84 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+public class Mail.ComposerWidget : Gtk.Grid {
+    construct {
+        var bold = new Gtk.ToggleButton ();
+        bold.tooltip_text = _("Bold (Ctrl+B)");
+        bold.image = new Gtk.Image.from_icon_name ("format-text-bold-symbolic", Gtk.IconSize.MENU);
+
+        var italic = new Gtk.ToggleButton ();
+        italic.tooltip_text = _("Italic (Ctrl+I)");
+        italic.image = new Gtk.Image.from_icon_name ("format-text-italic-symbolic", Gtk.IconSize.MENU);
+
+        var underline = new Gtk.ToggleButton ();
+        underline.tooltip_text = _("Underline (Ctrl+U)");
+        underline.image = new Gtk.Image.from_icon_name ("format-text-underline-symbolic", Gtk.IconSize.MENU);
+
+        var strikethrough = new Gtk.ToggleButton ();
+        strikethrough.tooltip_text = _("Strikethrough (Ctrl+%)");
+        strikethrough.image = new Gtk.Image.from_icon_name ("format-text-strikethrough-symbolic", Gtk.IconSize.MENU);
+
+        var formatting_buttons = new Gtk.Grid ();
+        formatting_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+        formatting_buttons.add (bold);
+        formatting_buttons.add (italic);
+        formatting_buttons.add (underline);
+        formatting_buttons.add (strikethrough);
+
+        var indent_more = new Gtk.Button.from_icon_name ("format-indent-more-symbolic", Gtk.IconSize.MENU);
+        indent_more.tooltip_text = _("Quote text (Ctrl+])");
+
+        var indent_less = new Gtk.Button.from_icon_name ("format-indent-less-symbolic", Gtk.IconSize.MENU);
+        indent_less.tooltip_text = _("Unquote text (Ctrl+[)");
+
+        var indent_buttons = new Gtk.Grid ();
+        indent_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+        indent_buttons.add (indent_more);
+        indent_buttons.add (indent_less);
+
+        var link = new Gtk.Button.from_icon_name ("insert-link-symbolic", Gtk.IconSize.MENU);
+        link.tooltip_text = _("Link (Ctrl+K)");
+
+        var image = new Gtk.Button.from_icon_name ("insert-image-symbolic", Gtk.IconSize.MENU);
+        image.tooltip_text = _("Image (Ctrl+G)");
+
+        var clear_format = new Gtk.Button.from_icon_name ("format-text-clear-formatting-symbolic", Gtk.IconSize.MENU);
+        clear_format.tooltip_text = _("Remove formatting (Ctrl+Space)");
+
+        var button_row = new Gtk.Grid ();
+        button_row.column_spacing = 6;
+        button_row.margin_left = 6;
+        button_row.margin_bottom = 6;
+        button_row.add (formatting_buttons);
+        button_row.add (indent_buttons);
+        button_row.add (link);
+        button_row.add (image);
+        button_row.add (clear_format);
+
+        var web_view = new WebView ();
+        web_view.editable = true;
+
+        orientation = Gtk.Orientation.VERTICAL;
+        add (button_row);
+        add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+        add (web_view);
+    }
+}

--- a/src/Composer/ComposerWindow.vala
+++ b/src/Composer/ComposerWindow.vala
@@ -63,62 +63,6 @@ public class Mail.ComposerWindow : Gtk.ApplicationWindow {
         recipient_grid.attach (subject_label, 0, 2, 1, 1);
         recipient_grid.attach (subject_val, 1, 2, 1, 1);
 
-        var bold = new Gtk.ToggleButton ();
-        bold.tooltip_text = _("Bold (Ctrl+B)");
-        bold.image = new Gtk.Image.from_icon_name ("format-text-bold-symbolic", Gtk.IconSize.MENU);
-
-        var italic = new Gtk.ToggleButton ();
-        italic.tooltip_text = _("Italic (Ctrl+I)");
-        italic.image = new Gtk.Image.from_icon_name ("format-text-italic-symbolic", Gtk.IconSize.MENU);
-
-        var underline = new Gtk.ToggleButton ();
-        underline.tooltip_text = _("Underline (Ctrl+U)");
-        underline.image = new Gtk.Image.from_icon_name ("format-text-underline-symbolic", Gtk.IconSize.MENU);
-
-        var strikethrough = new Gtk.ToggleButton ();
-        strikethrough.tooltip_text = _("Strikethrough (Ctrl+%)");
-        strikethrough.image = new Gtk.Image.from_icon_name ("format-text-strikethrough-symbolic", Gtk.IconSize.MENU);
-
-        var formatting_buttons = new Gtk.Grid ();
-        formatting_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        formatting_buttons.add (bold);
-        formatting_buttons.add (italic);
-        formatting_buttons.add (underline);
-        formatting_buttons.add (strikethrough);
-
-        var indent_more = new Gtk.Button.from_icon_name ("format-indent-more-symbolic", Gtk.IconSize.MENU);
-        indent_more.tooltip_text = _("Quote text (Ctrl+])");
-
-        var indent_less = new Gtk.Button.from_icon_name ("format-indent-less-symbolic", Gtk.IconSize.MENU);
-        indent_less.tooltip_text = _("Unquote text (Ctrl+[)");
-
-        var indent_buttons = new Gtk.Grid ();
-        indent_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        indent_buttons.add (indent_more);
-        indent_buttons.add (indent_less);
-
-        var link = new Gtk.Button.from_icon_name ("insert-link-symbolic", Gtk.IconSize.MENU);
-        link.tooltip_text = _("Link (Ctrl+K)");
-
-        var image = new Gtk.Button.from_icon_name ("insert-image-symbolic", Gtk.IconSize.MENU);
-        image.tooltip_text = _("Image (Ctrl+G)");
-
-        var clear_format = new Gtk.Button.from_icon_name ("format-text-clear-formatting-symbolic", Gtk.IconSize.MENU);
-        clear_format.tooltip_text = _("Remove formatting (Ctrl+Space)");
-
-        var button_row = new Gtk.Grid ();
-        button_row.column_spacing = 6;
-        button_row.margin_left = 6;
-        button_row.margin_bottom = 6;
-        button_row.add (formatting_buttons);
-        button_row.add (indent_buttons);
-        button_row.add (link);
-        button_row.add (image);
-        button_row.add (clear_format);
-
-        var web_view = new WebView ();
-        web_view.editable = true;
-
         var discard = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
         discard.margin_start = 6;
         discard.tooltip_text = _("Delete draft");
@@ -139,12 +83,12 @@ public class Mail.ComposerWindow : Gtk.ApplicationWindow {
         action_bar.pack_start (attach);
         action_bar.pack_end (send_button);
 
+        var composer_widget = new ComposerWidget ();
+
         var content_grid = new Gtk.Grid ();
         content_grid.orientation = Gtk.Orientation.VERTICAL;
         content_grid.add (recipient_grid);
-        content_grid.add (button_row);
-        content_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        content_grid.add (web_view);
+        content_grid.add (composer_widget);
         content_grid.add (action_bar);
 
         get_style_context ().add_class ("rounded");

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ vala_files = [
     'Backend/Session.vala',
     'Backend/Account.vala',
     'Composer/ComposerWindow.vala',
+    'Composer/ComposerWidget.vala',
     'FoldersView/AccountSourceItem.vala',
     'FoldersView/FoldersListView.vala',
     'FoldersView/FolderSourceItem.vala',


### PR DESCRIPTION
This supersedes part of #115. Just splitting it into parts to get a cleaner diff. This first part is a straight cut and paste of the widgets that will be used in both the inline and separate composers (so, the formatting bar and the webview). 