### PR TITLE
Sort starred messages to the top of the list

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -119,6 +119,18 @@ public class Mail.ConversationListBox : Gtk.ListBox {
     private static int thread_sort_function (Gtk.ListBoxRow row1, Gtk.ListBoxRow row2) {
         var item1 = (ConversationListItem) row1;
         var item2 = (ConversationListItem) row2;
-        return (int)(item2.node.message.date_received - item1.node.message.date_received);
+
+        var item1_starred = Camel.MessageFlags.FLAGGED in (int) item1.node.message.flags;
+        var item2_starred = Camel.MessageFlags.FLAGGED in (int) item2.node.message.flags;
+
+        if (item1_starred || item2_starred) {
+            if (item1_starred && !item2_starred) {
+                return -1;
+            } else {
+                return 1;
+            }
+        } else {
+            return (int)(item2.node.message.date_received - item1.node.message.date_received);
+        }
     }
 }


### PR DESCRIPTION
Following up on https://bugs.launchpad.net/pantheon-mail/+bug/1590976

Not so sure about this anymore for a couple of reasons:

1. There's a starred folder in the sidebar so these messages are already easy to get to
2. The listbox lazy loads so it won't show all starred messages from ever, only recent ones