### PR TITLE
Fix an oops

### DIFF
--- a/data/org.pantheon.mail.gschema.xml
+++ b/data/org.pantheon.mail.gschema.xml
@@ -2,10 +2,10 @@
 
 <schema id="org.pantheon.mail" path="/org/pantheon/mail/">
     
-    <key name="window-maximize" type="b">
+    <key name="window-maximized" type="b">
         <default>false</default>
         <summary>maximize window</summary>
-        <description>True if library application is maximized, false otherwise.</description>
+        <description>True if application is maximized, false otherwise.</description>
     </key>
     
     <key name="window-width" type="i">


### PR DESCRIPTION
Was getting quite a few `GLib-GIO-ERROR **: Settings schema 'io.elementary.mail' does not contain a key named 'window-maximized'` errors. `maximized` has been used throughout the code, missing a `d` in the schema.