### PR TITLE
Don't use time_t as a property

### DIFF
--- a/src/engine/imap-db/imap-db-message-row.vala
+++ b/src/engine/imap-db/imap-db-message-row.vala
@@ -7,276 +7,275 @@
 private class Geary.ImapDB.MessageRow {
     public int64 id { get; set; default = Db.INVALID_ROWID; }
     public Geary.Email.Field fields { get; set; default = Geary.Email.Field.NONE; }
-    
+
     public string? date { get; set; default = null; }
     public time_t date_time_t { get; set; default = -1; }
-    
+
     public string? from { get; set; default = null; }
     public string? sender { get; set; default = null; }
     public string? reply_to { get; set; default = null; }
-    
+
     public string? to { get; set; default = null; }
     public string? cc { get; set; default = null; }
     public string? bcc { get; set; default = null; }
-    
+
     public string? message_id { get; set; default = null; }
     public string? in_reply_to { get; set; default = null; }
     public string? references { get; set; default = null; }
-    
+
     public string? subject { get; set; default = null; }
-    
+
     public Memory.Buffer? header { get; set; default = null; }
-    
+
     public Memory.Buffer? body { get; set; default = null; }
-    
+
     public string? preview { get; set; default = null; }
-    
+
     public string? email_flags { get; set; default = null; }
     public string? internaldate { get; set; default = null; }
     public time_t internaldate_time_t { get; set; default = -1; }
     public int64 rfc822_size { get; set; default = -1; }
-    
+
     public MessageRow() {
     }
-    
+
     public MessageRow.from_email(Geary.Email email) {
         set_from_email(email);
     }
-    
+
     // Converts the current row of the Result object into fields.  It's vitally important that
     // the columns specified in requested_fields be present in Result.
     public MessageRow.from_result(Geary.Email.Field requested_fields, Db.Result results) throws Error {
         id = results.int64_for("id");
-        
+
         // the available fields are an intersection of what's available in the database and
         // what was requested
         fields = requested_fields & results.int_for("fields");
-        
+
         if (fields.is_all_set(Geary.Email.Field.DATE)) {
             date = results.string_for("date_field");
             date_time_t = (time_t) results.int64_for("date_time_t");
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.ORIGINATORS)) {
             from = results.string_for("from_field");
             sender = results.string_for("sender");
             reply_to = results.string_for("reply_to");
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.RECEIVERS)) {
             to = results.string_for("to_field");
             cc = results.string_for("cc");
             bcc = results.string_for("bcc");
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.REFERENCES)) {
             message_id = results.string_for("message_id");
             in_reply_to = results.string_for("in_reply_to");
             references = results.string_for("reference_ids");
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.SUBJECT))
             subject = results.string_for("subject");
-        
+
         if (fields.is_all_set(Geary.Email.Field.HEADER))
             header = results.string_buffer_for("header");
-        
+
         if (fields.is_all_set(Geary.Email.Field.BODY))
             body = results.string_buffer_for("body");
-        
+
         if (fields.is_all_set(Geary.Email.Field.PREVIEW))
             preview = results.string_for("preview");
-        
+
         if (fields.is_all_set(Geary.Email.Field.FLAGS))
             email_flags = results.string_for("flags");
-        
+
         if (fields.is_all_set(Geary.Email.Field.PROPERTIES)) {
             internaldate = results.string_for("internaldate");
             internaldate_time_t = (time_t) results.int64_for("internaldate_time_t");
             rfc822_size = results.int64_for("rfc822_size");
         }
     }
-    
+
     public Geary.Email to_email(ImapDB.EmailIdentifier id) throws Error {
         // Important to set something in the Email object if the field bit is set ... for example,
         // if the caller expects to see a DATE field, that field is set in the Email's bitmask,
         // even if the Date object is null
         Geary.Email email = new Geary.Email(id);
-        
+
         if (fields.is_all_set(Geary.Email.Field.DATE))
             email.set_send_date(!String.is_empty(date) ? new RFC822.Date(date) : null);
-        
+
         if (fields.is_all_set(Geary.Email.Field.ORIGINATORS)) {
             email.set_originators(unflatten_addresses(from), unflatten_addresses(sender),
                 unflatten_addresses(reply_to));
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.RECEIVERS)) {
             email.set_receivers(unflatten_addresses(to), unflatten_addresses(cc),
                 unflatten_addresses(bcc));
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.REFERENCES)) {
             email.set_full_references(
                 (message_id != null) ? new RFC822.MessageID(message_id) : null,
                 (in_reply_to != null) ? new RFC822.MessageIDList.from_rfc822_string(in_reply_to) : null,
                 (references != null) ? new RFC822.MessageIDList.from_rfc822_string(references) : null);
         }
-        
+
         if (fields.is_all_set(Geary.Email.Field.SUBJECT))
             email.set_message_subject(new RFC822.Subject.decode(subject ?? ""));
-        
+
         if (fields.is_all_set(Geary.Email.Field.HEADER))
             email.set_message_header(new RFC822.Header(header ?? Memory.EmptyBuffer.instance));
-        
+
         if (fields.is_all_set(Geary.Email.Field.BODY))
             email.set_message_body(new RFC822.Text(body ?? Memory.EmptyBuffer.instance));
-        
+
         if (fields.is_all_set(Geary.Email.Field.PREVIEW))
             email.set_message_preview(new RFC822.PreviewText(new Geary.Memory.StringBuffer(preview ?? "")));
-        
+
         if (fields.is_all_set(Geary.Email.Field.FLAGS))
             email.set_flags(get_generic_email_flags());
-        
+
         if (fields.is_all_set(Geary.Email.Field.PROPERTIES)) {
             Imap.EmailProperties? properties = get_imap_email_properties();
             if (properties != null)
                 email.set_email_properties(properties);
         }
-        
+
         return email;
     }
-    
-    
+
+
     public Geary.Imap.EmailProperties? get_imap_email_properties() {
         if (internaldate == null || rfc822_size < 0)
             return null;
-        
+
         Imap.InternalDate? constructed = null;
         try {
             constructed = Imap.InternalDate.decode(internaldate);
         } catch (Error err) {
             debug("Unable to construct internaldate object from \"%s\": %s", internaldate,
                 err.message);
-            
+
             return null;
         }
-        
+
         return new Geary.Imap.EmailProperties(constructed, new RFC822.Size(rfc822_size));
     }
-    
+
     public Geary.EmailFlags? get_generic_email_flags() {
         return (email_flags != null)
             ? new Geary.Imap.EmailFlags(Geary.Imap.MessageFlags.deserialize(email_flags))
             : null;
     }
-    
+
     public void merge_from_remote(Geary.Email email) {
         set_from_email(email);
     }
-    
+
     private void set_from_email(Geary.Email email) {
         // Although the fields bitmask might indicate various fields are set, they may still be
         // null if empty
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.DATE)) {
             date = (email.date != null) ? email.date.original : null;
-            date_time_t = (email.date != null) ? email.date.as_time_t : -1;
-            
+            date_time_t = (email.date != null) ? email.date.to_time_t () : -1;
+
             fields = fields.set(Geary.Email.Field.DATE);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.ORIGINATORS)) {
             from = flatten_addresses(email.from);
             sender = flatten_addresses(email.sender);
             reply_to = flatten_addresses(email.reply_to);
-            
+
             fields = fields.set(Geary.Email.Field.ORIGINATORS);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.RECEIVERS)) {
             to = flatten_addresses(email.to);
             cc = flatten_addresses(email.cc);
             bcc = flatten_addresses(email.bcc);
-            
+
             fields = fields.set(Geary.Email.Field.RECEIVERS);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.REFERENCES)) {
             message_id = (email.message_id != null) ? email.message_id.value : null;
             in_reply_to = (email.in_reply_to != null) ? email.in_reply_to.to_rfc822_string() : null;
             references = (email.references != null) ? email.references.to_rfc822_string() : null;
-            
+
             fields = fields.set(Geary.Email.Field.REFERENCES);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.SUBJECT)) {
             subject = (email.subject != null) ? email.subject.original : null;
-            
+
             fields = fields.set(Geary.Email.Field.SUBJECT);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.HEADER)) {
             header = (email.header != null) ? email.header.buffer : null;
-            
+
             fields = fields.set(Geary.Email.Field.HEADER);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.BODY)) {
             body = (email.body != null) ? email.body.buffer : null;
-            
+
             fields = fields.set(Geary.Email.Field.BODY);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.PREVIEW)) {
             preview = (email.preview != null) ? email.preview.buffer.to_string() : null;
-            
+
             fields = fields.set(Geary.Email.Field.PREVIEW);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.FLAGS)) {
             Geary.Imap.EmailFlags? imap_flags = (Geary.Imap.EmailFlags) email.email_flags;
             email_flags = (imap_flags != null) ? imap_flags.message_flags.serialize() : null;
-            
+
             fields = fields.set(Geary.Email.Field.FLAGS);
         }
-        
+
         if (email.fields.is_all_set(Geary.Email.Field.PROPERTIES)) {
             Geary.Imap.EmailProperties? imap_properties = (Geary.Imap.EmailProperties) email.properties;
             internaldate = (imap_properties != null) ? imap_properties.internaldate.serialize() : null;
-            internaldate_time_t = (imap_properties != null) ? imap_properties.internaldate.as_time_t : -1;
+            internaldate_time_t = (imap_properties != null) ? imap_properties.internaldate.to_time_t () : -1;
             rfc822_size = (imap_properties != null) ? imap_properties.rfc822_size.value : -1;
-            
+
             fields = fields.set(Geary.Email.Field.PROPERTIES);
         }
     }
-    
+
     private static string? flatten_addresses(RFC822.MailboxAddresses? addrs) {
         if (addrs == null)
             return null;
-        
+
         switch (addrs.size) {
             case 0:
                 return null;
-            
+
             case 1:
                 return addrs[0].to_rfc822_string();
-            
+
             default:
                 StringBuilder builder = new StringBuilder();
                 foreach (RFC822.MailboxAddress addr in addrs) {
                     if (!String.is_empty(builder.str))
                         builder.append(", ");
-                    
+
                     builder.append(addr.to_rfc822_string());
                 }
-                
+
                 return builder.str;
         }
     }
-    
+
     private RFC822.MailboxAddresses? unflatten_addresses(string? str) {
         return String.is_empty(str) ? null : new RFC822.MailboxAddresses.from_rfc822_string(str);
     }
 }
-

--- a/src/engine/imap/message/imap-internal-date.vala
+++ b/src/engine/imap/message/imap-internal-date.vala
@@ -22,33 +22,30 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
     private const string[] EN_US_MON = {
         "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     };
-    
+
     private const string[] EN_US_MON_DOWN = {
         "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"
     };
-    
+
     public DateTime value { get; private set; }
-    public time_t as_time_t { get; private set; }
     public string? original { get; private set; default = null; }
-    
+
     private InternalDate(string original, DateTime datetime) {
         this.original = original;
         value = datetime;
-        as_time_t = Time.datetime_to_time_t(datetime);
     }
-    
+
     public InternalDate.from_date_time(DateTime datetime) throws ImapError {
         value = datetime;
-        as_time_t = Time.datetime_to_time_t(datetime);
     }
-    
+
     public static InternalDate decode(string internaldate) throws ImapError {
         if (String.is_empty(internaldate))
             throw new ImapError.PARSE_ERROR("Invalid INTERNALDATE: empty string");
-        
+
         if (internaldate.length > 64)
             throw new ImapError.PARSE_ERROR("Invalid INTERNALDATE: too long (%d)", internaldate.length);
-        
+
         // Alas, GMime.utils_header_decode_date() is too forgiving for our needs, so do it manually
         int day, year, hour, min, sec;
         char mon[4] = { 0 };
@@ -57,7 +54,7 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
             out min, out sec, tz);
         if (count != 6 && count != 7)
             throw new ImapError.PARSE_ERROR("Invalid INTERNALDATE \"%s\": too few fields (%d)", internaldate, count);
-        
+
         // check numerical ranges; this does not verify this is an actual date, DateTime will do
         // that (and round upward, which has to be accepted)
         if (!Numeric.int_in_range_inclusive(day, 1, 31)
@@ -67,40 +64,47 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
             || year < 1970) {
             throw new ImapError.PARSE_ERROR("Invalid INTERNALDATE \"%s\": bad numerical range", internaldate);
         }
-        
+
         // check month (this catches localization problems)
         int month = -1;
         string mon_down = Ascii.strdown(((string) mon));
         for (int ctr = 0; ctr < EN_US_MON_DOWN.length; ctr++) {
             if (mon_down == EN_US_MON_DOWN[ctr]) {
                 month = ctr;
-                
+
                 break;
             }
         }
-        
+
         if (month < 0)
             throw new ImapError.PARSE_ERROR("Invalid INTERNALDATE \"%s\": bad month", internaldate);
-        
+
         // TODO: verify timezone
-        
+
         // if no timezone listed, ISO 8601 says to use local time
         TimeZone timezone = (tz[0] != '\0') ? new TimeZone((string) tz) : new TimeZone.local();
-        
+
         // assemble into DateTime, which validates the time as well (this is why we want to keep
         // original around, for other reasons) ... month is 1-based in DateTime
         DateTime datetime = new DateTime(timezone, year, month + 1, day, hour, min, sec);
-        
+
         return new InternalDate(internaldate, datetime);
     }
-    
+
+    /**
+     * Returns the value of the InternalDate as a time_t representation.
+     */
+    public time_t to_time_t () {
+        return Time.datetime_to_time_t (value);
+    }
+
     /**
      * Returns the {@link InternalDate} as a {@link Parameter}.
      */
     public Parameter to_parameter() {
         return Parameter.get_for_string(serialize());
     }
-    
+
     /**
      * Returns the {@link InternalDate} as a {@link Parameter} for a {@link SearchCriterion}.
      *
@@ -109,7 +113,7 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
     public Parameter to_search_parameter() {
         return Parameter.get_for_string(serialize_for_search());
     }
-    
+
     /**
      * Returns the {@link InternalDate}'s string representation.
      *
@@ -118,7 +122,7 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
     public string serialize() {
         return original ?? value.format("%d-%%s-%Y %H:%M:%S %z").printf(get_en_us_mon());
     }
-    
+
     /**
      * Returns the {@link InternalDate}'s string representation for a SEARCH command.
      *
@@ -131,7 +135,7 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
     public string serialize_for_search() {
         return value.format("%d-%%s-%Y").printf(get_en_us_mon());
     }
-    
+
     /**
      * Because IMAP's INTERNALDATE strings are ''never'' localized (as best as I can gather), so
      * need to use en_US appreviated month names, as that's the only value in INTERNALDATE that is
@@ -140,24 +144,23 @@ public class Geary.Imap.InternalDate : Geary.MessageData.AbstractMessageData, Ge
     private string get_en_us_mon() {
         // month is 1-based inside of DateTime
         int mon = (value.get_month() - 1).clamp(0, EN_US_MON.length - 1);
-        
+
         return EN_US_MON[mon];
     }
-    
+
     public uint hash() {
         return value.hash();
     }
-    
+
     public bool equal_to(InternalDate other) {
         return value.equal(other.value);
     }
-    
+
     public int compare_to(InternalDate other) {
         return value.compare(other.value);
     }
-    
+
     public override string to_string() {
         return serialize();
     }
 }
-


### PR DESCRIPTION
Fixes #184 

Looks like my editor went and cleaned up a load of trailing whitespace, but it's a simple patch taken from [here](https://github.com/GNOME/geary/commit/383ee159928386e7ed9b7265f8c5863514a0dab7) and [here](https://github.com/GNOME/geary/commit/756cc39d8de0f1b1340ba963274e5073b99515ba).