### PR TITLE
EDS rewrite: Minor display fixes

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -21,8 +21,8 @@
  */
 
 public class Mail.ConversationListBox : Gtk.ListBox {
-    public signal void conversation_selected (Camel.FolderThreadNode node);
-    public signal void conversation_focused (Camel.FolderThreadNode node);
+    public signal void conversation_selected (Camel.FolderThreadNode? node);
+    public signal void conversation_focused (Camel.FolderThreadNode? node);
 
     private string current_folder;
     private Backend.Account current_account;
@@ -37,10 +37,18 @@ public class Mail.ConversationListBox : Gtk.ListBox {
         conversations = new Gee.HashMap<string, ConversationListItem> ();
         set_sort_func (thread_sort_function);
         row_activated.connect ((row) => {
-            conversation_focused (((ConversationListItem) row).node);
+            if (row == null) {
+                conversation_focused (null);
+            } else {
+                conversation_focused (((ConversationListItem) row).node);
+            }
         });
         row_selected.connect ((row) => {
-            conversation_selected (((ConversationListItem) row).node);
+            if (row == null) {
+                conversation_selected (null);
+            } else {
+                conversation_selected (((ConversationListItem) row).node);
+            }
         });
     }
 
@@ -50,6 +58,9 @@ public class Mail.ConversationListBox : Gtk.ListBox {
         if (cancellable != null) {
             cancellable.cancel ();
         }
+
+        conversation_focused (null);
+        conversation_selected (null);
 
         lock (conversations) {
             conversations.clear ();

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -129,7 +129,17 @@ public class Mail.ConversationListBox : Gtk.ListBox {
 
     private static int thread_sort_function (Gtk.ListBoxRow row1, Gtk.ListBoxRow row2) {
         var item1 = (ConversationListItem) row1;
+        var timestamp1 = item1.node.message.date_received;
+        if (timestamp1 == 0) {
+            timestamp1 = item1.node.message.date_sent;
+        }
+
         var item2 = (ConversationListItem) row2;
-        return (int)(item2.node.message.date_received - item1.node.message.date_received);
+        var timestamp2 = item2.node.message.date_received;
+        if (timestamp2 == 0) {
+            timestamp2 = item2.node.message.date_sent;
+        }
+
+        return (int)(timestamp2 - timestamp1);
     }
 }

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -129,17 +129,8 @@ public class Mail.ConversationListBox : Gtk.ListBox {
 
     private static int thread_sort_function (Gtk.ListBoxRow row1, Gtk.ListBoxRow row2) {
         var item1 = (ConversationListItem) row1;
-        var timestamp1 = item1.node.message.date_received;
-        if (timestamp1 == 0) {
-            timestamp1 = item1.node.message.date_sent;
-        }
-
         var item2 = (ConversationListItem) row2;
-        var timestamp2 = item2.node.message.date_received;
-        if (timestamp2 == 0) {
-            timestamp2 = item2.node.message.date_sent;
-        }
 
-        return (int)(timestamp2 - timestamp1);
+        return (int)(item2.timestamp - item1.timestamp);
     }
 }

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -30,6 +30,16 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
 
     public Camel.FolderThreadNode node { get; private set; }
 
+    public int64 timestamp {
+        get {
+            if (node.message.date_received == 0) {
+                // Sent messages do not have a date_received timestamp.
+                return node.message.date_sent;
+            }
+            return node.message.date_received;
+        }
+    }
+
     public ConversationListItem (Camel.FolderThreadNode node) {
         update_node (node);
     }
@@ -108,12 +118,7 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
             flagged_icon_revealer.reveal_child = true;
         }
 
-        var relevant_timestamp = node.message.date_received;
-        if (relevant_timestamp == 0) {
-            // Sent messages do not have a date_received timestamp.
-            relevant_timestamp = node.message.date_sent;
-        }
-        date.label = Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (relevant_timestamp));
+        date.label = Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (timestamp));
     }
 
     private static uint count_thread_messages (Camel.FolderThreadNode node) {

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -108,7 +108,12 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
             flagged_icon_revealer.reveal_child = true;
         }
 
-        date.label = Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (node.message.date_received));
+        var relevant_timestamp = node.message.date_received;
+        if (relevant_timestamp == 0) {
+            // Sent messages do not have a date_received timestamp.
+            relevant_timestamp = node.message.date_sent;
+        }
+        date.label = Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (relevant_timestamp));
     }
 
     private static uint count_thread_messages (Camel.FolderThreadNode node) {

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -31,14 +31,15 @@ public class Mail.MessageListBox : Gtk.ListBox {
     }
 
     public void set_conversation (Camel.FolderThreadNode? node) {
+        // Prevent the user from interacting with the message thread while it
+        // is being reloaded. can_reply will be set to true after loading the
+        // thread.
+        can_reply = false;
+
         get_children ().foreach ((child) => {
             child.destroy ();
         });
 
-        // Prevent the user from interacting with the message thread while it
-        // is being loaded. can_reply will be set to true after loading the
-        // thread (if any).
-        can_reply = false;
         if (node == null)
             return;
 

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -30,10 +30,17 @@ public class Mail.MessageListBox : Gtk.ListBox {
         get_style_context ().add_class ("deck");
     }
 
-    public void set_conversation (Camel.FolderThreadNode node) {
+    public void set_conversation (Camel.FolderThreadNode? node) {
         get_children ().foreach ((child) => {
             child.destroy ();
         });
+
+        // Prevent the user from interacting with the message thread while it
+        // is being loaded. can_reply will be set to true after loading the
+        // thread (if any).
+        can_reply = false;
+        if (node == null)
+            return;
 
         var item = new MessageListItem (node.message);
         add (item);
@@ -42,14 +49,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
         }
 
         var children = get_children ();
-        if (children.length () == 1) {
-            var child = get_row_at_index (0);
-            if (child is MessageListItem) {
-                var list_item = (MessageListItem) child;
-                list_item.expanded = true;
-                list_item.bind_property ("loaded", this, "can-reply", BindingFlags.SYNC_CREATE);
-            }
-        } else {
+        if (children.length () > 0) {
             var child = get_row_at_index ((int) children.length () - 1);
             if (child != null && child is MessageListItem) {
                 var list_item = (MessageListItem) child;

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -139,7 +139,12 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         header_stack.add_named (small_fields_grid, "small");
         header_stack.show_all ();
 
-        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (message_info.date_received).format ("%b %e, %Y"));
+        var relevant_timestamp = message_info.date_received;
+        if (relevant_timestamp == 0) {
+            // Sent messages do not have a date_received timestamp.
+            relevant_timestamp = message_info.date_sent;
+        }
+        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).format ("%b %e, %Y"));
         datetime_label.hexpand = true;
         datetime_label.halign = Gtk.Align.END;
         datetime_label.valign = Gtk.Align.START;


### PR DESCRIPTION
Two small fixes:

* When opening an empty folder, the previous conversation remains selected (unlike on the non-EDS master build). I've made the selected conversation an optional parameter, and null indicates no selection.
* I've sent myself a few mails using Evolution and they have no `date_received`. I've changed the code to fall back on the `date_sent` field in this case.