### PR TITLE
EDS rewrite: Correct encoding, display plain text emails

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -389,6 +389,16 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             }
 
             message_content = (string) os.steal_data ();
+
+            if (!message_content.validate ()) {
+                // If message_content is not valid UTF-8, assume that it is
+                // ISO-8859-1 encoded and convert it to UTF-8.
+                // This prevents silent rendering failures down the line because
+                // WebKit's load_plain_text can only handle valid UTF-8 strings.
+                // TODO: This should use the correct encoding from the Content-Type header.
+                message_content = GLib.convert (message_content, -1, "UTF-8", "ISO-8859-1");
+            }
+
             if (field.subtype == "html") {
                 message_is_html = true;
             }

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -418,7 +418,6 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             // If message_content is not valid UTF-8 at this point, assume that
             // it is ISO-8859-1 encoded by default, and convert it to UTF-8.
             try {
-                warning ("No encoding/charset found for email; using ISO-8859-1");
                 result = GLib.convert (bytes, num_bytes, "UTF-8", "ISO-8859-1");
             } catch (ConvertError e) {
                 critical("Every string should be valid ISO-8859-1");

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -353,13 +353,26 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         if (message_is_html) {
             web_view.load_html (message_content);
         } else {
-            web_view.load_plain_text (message_content);
+            /*
+             * Instead of calling web_view.load_plain_text, use Camel's ToHTML
+             * filter to convert text to HTML. This gives us some niceties like
+             * clickable URLs and email addresses for free.
+             *
+             * Explanation of MimeFilterToHTMLFlags:
+             * https://wiki.gnome.org/Apps/Evolution/Camel.MimeFilter#Camel.MimeFilterToHtml
+             */
+            var flags = Camel.MimeFilterToHTMLFlags.CONVERT_NL |
+                Camel.MimeFilterToHTMLFlags.CONVERT_SPACES |
+                Camel.MimeFilterToHTMLFlags.CONVERT_URLS |
+                Camel.MimeFilterToHTMLFlags.CONVERT_ADDRESSES;
+            var html = Camel.text_to_html (message_content, flags, 0);
+            web_view.load_html (html);
         }
     }
 
-    private async void parse_mime_content (Camel.DataWrapper message_content) {
-        if (message_content is Camel.Multipart) {
-            var content = message_content as Camel.Multipart;
+    private async void parse_mime_content (Camel.DataWrapper mime_content) {
+        if (mime_content is Camel.Multipart) {
+            var content = mime_content as Camel.Multipart;
             for (uint i = 0; i < content.get_number (); i++) {
                 var part = content.get_part (i);
                 var field = part.get_mime_type_field ();
@@ -372,7 +385,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
                 }
             }
         } else {
-            yield handle_text_mime (message_content);
+            yield handle_text_mime (mime_content);
         }
     }
 
@@ -389,7 +402,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             }
 
             // Convert the message to UTF-8 to ensure we have a valid GLib string.
-            message_content = convert_to_utf8(os, field.param ("charset"));
+            message_content = convert_to_utf8 (os, field.param ("charset"));
 
             if (field.subtype == "html") {
                 message_is_html = true;
@@ -397,7 +410,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         }
     }
 
-    private static string convert_to_utf8(GLib.MemoryOutputStream os, string? encoding) {
+    private static string convert_to_utf8 (GLib.MemoryOutputStream os, string? encoding) {
         var num_bytes = (int) os.get_data_size ();
         var bytes = (string) os.steal_data ();
 
@@ -414,13 +427,16 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             }
         }
 
-        if (utf8 == null || !utf8.validate()) {
-            // If message_content is not valid UTF-8 at this point, assume that
-            // it is ISO-8859-1 encoded by default, and convert it to UTF-8.
+        if (utf8 == null || !utf8.validate ()) {
+            /*
+             * If message_content is not valid UTF-8 at this point, assume that
+             * it is ISO-8859-1 encoded by default, and convert it to UTF-8.
+             */
             try {
                 utf8 = GLib.convert (bytes, num_bytes, "UTF-8", "ISO-8859-1");
             } catch (ConvertError e) {
-                critical("Every string should be valid ISO-8859-1");
+                critical ("Every string should be valid ISO-8859-1. ConvertError: %s", e.message);
+                utf8 = "";
             }
         }
 
@@ -438,8 +454,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             return;
         }
 
-        Bytes bytes;
-        bytes = ByteArray.free_to_bytes (byte_array);
+        Bytes bytes = ByteArray.free_to_bytes (byte_array);
         var inline_stream = new MemoryInputStream.from_bytes (bytes);
         web_view.add_internal_resource (part.get_content_id (), inline_stream);
     }

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -398,33 +398,33 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
     }
 
     private static string convert_to_utf8(GLib.MemoryOutputStream os, string? encoding) {
-    	var num_bytes = (int) os.get_data_size ();
-		var bytes = (string) os.steal_data ();
+        var num_bytes = (int) os.get_data_size ();
+        var bytes = (string) os.steal_data ();
 
-		string? result = null;
+        string? utf8 = null;
 
         if (encoding != null) {
             string? iconv_encoding = Camel.iconv_charset_name (encoding);
             if (iconv_encoding != null) {
                 try {
-                    result = GLib.convert (bytes, num_bytes, "UTF-8", iconv_encoding);
+                    utf8 = GLib.convert (bytes, num_bytes, "UTF-8", iconv_encoding);
                 } catch (ConvertError e) {
                     // Nothing to do - result will be assigned below.
                 }
             }
         }
 
-        if (result == null || !result.validate()) {
+        if (utf8 == null || !utf8.validate()) {
             // If message_content is not valid UTF-8 at this point, assume that
             // it is ISO-8859-1 encoded by default, and convert it to UTF-8.
             try {
-                result = GLib.convert (bytes, num_bytes, "UTF-8", "ISO-8859-1");
+                utf8 = GLib.convert (bytes, num_bytes, "UTF-8", "ISO-8859-1");
             } catch (ConvertError e) {
                 critical("Every string should be valid ISO-8859-1");
             }
         }
 
-        return result;
+        return utf8;
     }
 
     private async void handle_inline_mime (Camel.MimePart part) {

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -160,6 +160,16 @@ public class Mail.WebView : WebKit.WebView {
         }
     }
 
+    public new void load_plain_text (string plain_text) {
+        var flags = Camel.MimeFilterToHTMLFlags.CONVERT_NL |
+            Camel.MimeFilterToHTMLFlags.CONVERT_SPACES |
+            Camel.MimeFilterToHTMLFlags.CONVERT_URLS |
+            Camel.MimeFilterToHTMLFlags.CONVERT_ADDRESSES;
+        // TODO: Which color should we use instead of 0 (black)?
+        var html = Camel.text_to_html (plain_text, flags, 0);
+        load_html (html);
+    }
+
     public void set_body_content (string content) {
         if (loaded) {
             extension.set_body_html (get_page_id (), content);

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -161,11 +161,16 @@ public class Mail.WebView : WebKit.WebView {
     }
 
     public new void load_plain_text (string plain_text) {
+        // Instead of calling base.load_plain_text, use Camel's ToHTML filter to
+        // convert text to HTML. This gives us some niceties like clickable URLs
+        // and email addresses.
+
+        // Explanation of ToHTML flags:
+        // https://wiki.gnome.org/Apps/Evolution/Camel.MimeFilter#Camel.MimeFilterToHtml
         var flags = Camel.MimeFilterToHTMLFlags.CONVERT_NL |
             Camel.MimeFilterToHTMLFlags.CONVERT_SPACES |
             Camel.MimeFilterToHTMLFlags.CONVERT_URLS |
             Camel.MimeFilterToHTMLFlags.CONVERT_ADDRESSES;
-        // TODO: Which color should we use instead of 0 (black)?
         var html = Camel.text_to_html (plain_text, flags, 0);
         load_html (html);
     }

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -160,21 +160,6 @@ public class Mail.WebView : WebKit.WebView {
         }
     }
 
-    public new void load_plain_text (string plain_text) {
-        // Instead of calling base.load_plain_text, use Camel's ToHTML filter to
-        // convert text to HTML. This gives us some niceties like clickable URLs
-        // and email addresses.
-
-        // Explanation of ToHTML flags:
-        // https://wiki.gnome.org/Apps/Evolution/Camel.MimeFilter#Camel.MimeFilterToHtml
-        var flags = Camel.MimeFilterToHTMLFlags.CONVERT_NL |
-            Camel.MimeFilterToHTMLFlags.CONVERT_SPACES |
-            Camel.MimeFilterToHTMLFlags.CONVERT_URLS |
-            Camel.MimeFilterToHTMLFlags.CONVERT_ADDRESSES;
-        var html = Camel.text_to_html (plain_text, flags, 0);
-        load_html (html);
-    }
-
     public void set_body_content (string content) {
         if (loaded) {
             extension.set_body_html (get_page_id (), content);


### PR DESCRIPTION
I couldn't read plain text mails in my inbox and tracked it down to two issues:

* The messages were ISO-8859 encoded, and WebView.load_plain_text fails on invalid UTF-8 strings. I have fixed this by converting message contents to UTF-8 where they are loaded.
* WebView.load_plain_text was not overridden to set the load_changed handler like WebView.load_html. I've added an implementation using Camel's text-to-HTML filter.

Re: encoding stuff, it feels odd to have so much model logic in MessageListItem. Should I move the asynchronous message decoding to a helper class?