### PR TITLE
Stop WebView from leaking and deadlocking the app

### DIFF
--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -46,6 +46,7 @@ public class Mail.WebView : WebKit.WebView {
 
     private int preferred_height = 0;
     private MailWebViewExtension.Server? extension = null;
+    private uint watch_identifier = 0;
     private Gee.Map<string, InputStream> internal_resources;
 
     private bool ready = false;
@@ -74,7 +75,7 @@ public class Mail.WebView : WebKit.WebView {
 
         decide_policy.connect (on_decide_policy);
 
-        Bus.watch_name (BusType.SESSION, SERVER_BUS_NAME, BusNameWatcherFlags.NONE, on_server_appear);
+        watch_identifier = Bus.watch_name (BusType.SESSION, SERVER_BUS_NAME, BusNameWatcherFlags.NONE, on_server_appear);
     }
 
     public WebView () {
@@ -99,6 +100,12 @@ public class Mail.WebView : WebKit.WebView {
         } catch (IOError e) {
             warning ("Couldn't connect to WebKit extension DBus: %s", e.message);
         }
+
+        /*
+         * Stop waiting for the extension, to prevent this WebView from leaking
+         * via the method reference given to Bus.watch_name.
+         */
+        Bus.unwatch_name (watch_identifier);
 
         on_ready ();
     }


### PR DESCRIPTION
Steps to deadlock the app on the current rewrite branch:

* Select a folder with at least two conversations.
* Open a conversation that needs to load remote images..
* Select another conversation _before_ the current message finishes loading (reply arrows are still disabled -- easiest way is to reproduce is by hitting an arrow key)

This PR fixes this issue, although I haven't checked why this is the case. I only meant to stop WebViews from leaking - `Bus.watch_name` was keeping them alive indefinitely.