### PR TITLE
Move messages to trash

### DIFF
--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -68,7 +68,7 @@ public class Mail.Backend.Session : Camel.Session {
                 return;
             }
 
-            weak E.SourceMailAccount extension = (E.SourceMailAccount)source_item.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+            weak E.SourceMailAccount extension = (E.SourceMailAccount) source_item.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
             var backend_name = ((E.SourceBackend) extension).get_backend_name ();
             try {
                 add_service (uid, backend_name, Camel.ProviderType.STORE);
@@ -93,7 +93,7 @@ public class Mail.Backend.Session : Camel.Session {
             mechanism = null;
         }
 
-        if(mechanism != null) {
+        if (mechanism != null) {
             /* APOP is one case where a non-SASL mechanism name is passed, so
              * don't bail if the CamelServiceAuthType struct comes back NULL. */
             authtype = Camel.Sasl.authtype (mechanism);
@@ -137,7 +137,7 @@ public class Mail.Backend.Session : Camel.Session {
 
             var credentials_prompter = new E.CredentialsPrompter (registry);
             credentials_prompter.set_auto_prompt (true);
-             return credentials_prompter.loop_prompt_sync (source, E.CredentialsPrompterPromptFlags.ALLOW_SOURCE_SAVE, (prompter, source, credentials, out out_authenticated, cancellable) => try_credentials_sync (prompter, source, credentials, out out_authenticated, cancellable, service, mechanism));
+            return credentials_prompter.loop_prompt_sync (source, E.CredentialsPrompterPromptFlags.ALLOW_SOURCE_SAVE, (prompter, source, credentials, out out_authenticated, cancellable) => try_credentials_sync (prompter, source, credentials, out out_authenticated, cancellable, service, mechanism));
         } else {
             return (result == Camel.AuthenticationResult.ACCEPTED);
         }

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -91,8 +91,9 @@ public class Mail.ConversationListBox : Gtk.ListBox {
     }
 
     private void folder_changed (Camel.FolderChangeInfo change_info, GLib.Cancellable cancellable) {
-        if (cancellable.is_cancelled ())
+        if (cancellable.is_cancelled ()) {
             return;
+        }
 
         lock (conversations) {
             thread.apply (folder.get_uids ());
@@ -106,8 +107,9 @@ public class Mail.ConversationListBox : Gtk.ListBox {
 
             unowned Camel.FolderThreadNode? child = (Camel.FolderThreadNode?) thread.tree;
             while (child != null) {
-                if (cancellable.is_cancelled ())
+                if (cancellable.is_cancelled ()) {
                     return;
+                }
 
                 var item = conversations[child.message.uid];
                 if (item == null) {

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -32,7 +32,6 @@ public class Mail.ConversationListBox : Gtk.ListBox {
     private Gee.HashMap<string, ConversationListItem> conversations;
 
     construct {
-        selection_mode = Gtk.SelectionMode.MULTIPLE;
         activate_on_single_click = true;
         conversations = new Gee.HashMap<string, ConversationListItem> ();
         set_sort_func (thread_sort_function);

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -24,11 +24,12 @@ public class Mail.ConversationListBox : Gtk.ListBox {
     public signal void conversation_selected (Camel.FolderThreadNode? node);
     public signal void conversation_focused (Camel.FolderThreadNode? node);
 
-    private string current_folder;
-    private Backend.Account current_account;
+    public Backend.Account current_account { get; private set; }
+    public Camel.Folder folder { get; private set; }
+
     private GLib.Cancellable? cancellable = null;
-    private Camel.Folder folder;
     private Camel.FolderThread thread;
+    private string current_folder;
     private Gee.HashMap<string, ConversationListItem> conversations;
 
     construct {
@@ -51,7 +52,7 @@ public class Mail.ConversationListBox : Gtk.ListBox {
         });
     }
 
-    public async void set_folder (Backend.Account account, string next_folder) {
+    public async void load_folder (Backend.Account account, string next_folder) {
         current_folder = next_folder;
         current_account = account;
         if (cancellable != null) {

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -90,12 +90,18 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         forward_button.tooltip_text = _("Forward (Ctrl+Shift+F)");
         forward_button.action_name = "win." + MainWindow.ACTION_FORWARD;
 
+        var trash_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
+        trash_button.tooltip_text = _("Move conversations to Trash (Delete, Backspace)");
+        trash_button.action_name = "win." + MainWindow.ACTION_TRASH;
+
         pack_start (compose_button);
         pack_start (spacing_widget);
         pack_start (search_entry);
         pack_start (reply_button);
         pack_start (reply_all_button);
         pack_start (forward_button);
+        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        pack_start (trash_button);
         pack_end (app_menu);
 
         account_settings_menuitem.clicked.connect (() => {

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -92,7 +92,7 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
 
         var trash_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
         trash_button.tooltip_text = _("Move conversations to Trash (Delete, Backspace)");
-        trash_button.action_name = "win." + MainWindow.ACTION_TRASH;
+        trash_button.action_name = "win." + MainWindow.ACTION_MOVE_TO_TRASH;
 
         pack_start (compose_button);
         pack_start (spacing_widget);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -34,12 +34,14 @@ public class Mail.MainWindow : Gtk.Window {
     public const string ACTION_REPLY = "reply";
     public const string ACTION_REPLY_ALL = "reply-all";
     public const string ACTION_FORWARD = "forward";
+    public const string ACTION_TRASH = "trash";
 
     private const ActionEntry[] action_entries = {
         {ACTION_COMPOSE_MESSAGE,    on_compose_message   },
         {ACTION_REPLY,              on_reply             },
         {ACTION_REPLY_ALL,          on_reply_all         },
-        {ACTION_FORWARD,            on_forward           }
+        {ACTION_FORWARD,            on_forward           },
+        {ACTION_TRASH,              on_trash             },
     };
 
     public MainWindow () {
@@ -65,6 +67,7 @@ public class Mail.MainWindow : Gtk.Window {
         message_list_box.bind_property ("can-reply", get_action (ACTION_REPLY), "enabled", BindingFlags.SYNC_CREATE);
         message_list_box.bind_property ("can-reply", get_action (ACTION_REPLY_ALL), "enabled", BindingFlags.SYNC_CREATE);
         message_list_box.bind_property ("can-reply", get_action (ACTION_FORWARD), "enabled", BindingFlags.SYNC_CREATE);
+        message_list_box.bind_property ("can-move-thread", get_action (ACTION_TRASH), "enabled", BindingFlags.SYNC_CREATE);
 
         var conversation_list_scrolled = new Gtk.ScrolledWindow (null, null);
         conversation_list_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -163,6 +166,10 @@ public class Mail.MainWindow : Gtk.Window {
     private void on_forward () {
         scroll_message_list_to_bottom ();
         message_list_box.add_inline_composer (ComposerWidget.Type.FORWARD);
+    }
+
+    private void on_trash () {
+        // TODO
     }
 
     private SimpleAction? get_action (string name) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -173,6 +173,9 @@ public class Mail.MainWindow : Gtk.Window {
             var account = conversation_list_box.current_account;
             var offline_store = (Camel.OfflineStore) account.service;
             var trash_folder = offline_store.get_trash_folder_sync ();
+            if (trash_folder == null) {
+                critical ("Could not find trash folder in account " + account.service.display_name);
+            }
 
             var folder = conversation_list_box.folder;
             var uids = message_list_box.uids;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -177,9 +177,17 @@ public class Mail.MainWindow : Gtk.Window {
                 critical ("Could not find trash folder in account " + account.service.display_name);
             }
 
-            var folder = conversation_list_box.folder;
+            var source_folder = conversation_list_box.folder;
             var uids = message_list_box.uids;
-            folder.transfer_messages_to_sync (uids, trash_folder, true, null);
+
+            trash_folder.freeze ();
+            source_folder.freeze ();
+            try {
+                source_folder.transfer_messages_to_sync (uids, trash_folder, true, null);
+            } finally {
+                trash_folder.thaw ();
+                source_folder.thaw ();
+            }
         } catch (Error e) {
             critical ("Could not move messages to trash: " + e.message);
         }

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -22,6 +22,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
     public signal void hovering_over_link (string? label, string? uri);
     public bool can_reply { get; set; default = false; }
     public bool can_move_thread { get; set; default = false; }
+    public GenericArray<string> uids { get; private set; default = new GenericArray<string>(); }
 
     public MessageListBox () {
         Object (selection_mode: Gtk.SelectionMode.NONE);
@@ -43,6 +44,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
         get_children ().foreach ((child) => {
             child.destroy ();
         });
+        uids = new GenericArray<string> ();
 
         if (node == null) {
             return;
@@ -56,6 +58,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
 
         var item = new MessageListItem (node.message);
         add (item);
+        uids.add (node.message.uid);
         if (node.child != null) {
             go_down ((Camel.FolderThreadNode?) node.child);
         }
@@ -77,6 +80,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
         while (current_node != null) {
             var item = new MessageListItem (current_node.message);
             add (item);
+            uids.add (current_node.message.uid);
             if (current_node.next != null) {
                 go_down ((Camel.FolderThreadNode?) current_node.next);
             }

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -57,8 +57,9 @@ public class Mail.MessageListBox : Gtk.ListBox {
         }
 
         var children = get_children ();
-        if (children.length () > 0) {
-            var child = get_row_at_index ((int) children.length () - 1);
+        var num_children = children.length ();
+        if (num_children > 0) {
+            var child = get_row_at_index ((int) num_children - 1);
             if (child != null && child is MessageListItem) {
                 var list_item = (MessageListItem) child;
                 list_item.expanded = true;

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -21,6 +21,7 @@
 public class Mail.MessageListBox : Gtk.ListBox {
     public signal void hovering_over_link (string? label, string? uri);
     public bool can_reply { get; set; default = false; }
+    public bool can_move_thread { get; set; default = false; }
 
     public MessageListBox () {
         Object (selection_mode: Gtk.SelectionMode.NONE);
@@ -35,6 +36,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
         // is being reloaded. can_reply will be set to true after loading the
         // thread.
         can_reply = false;
+        can_move_thread = false;
 
         get_children ().foreach ((child) => {
             child.destroy ();
@@ -43,6 +45,10 @@ public class Mail.MessageListBox : Gtk.ListBox {
         if (node == null) {
             return;
         }
+
+        // If there is a node, we can move the thread even without loading all
+        // individual messages.
+        can_move_thread = true;
 
         var item = new MessageListItem (node.message);
         add (item);
@@ -91,11 +97,13 @@ public class Mail.MessageListBox : Gtk.ListBox {
             var composer = new InlineComposer (type, message_info, mime_message, content_to_quote);
             composer.discarded.connect (() => {
                 can_reply = true;
+                can_move_thread = true;
                 remove (composer);
                 composer.destroy ();
             });
             add (composer);
             can_reply = false;
+            can_move_thread = true;
         }
     }
 }

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -32,9 +32,11 @@ public class Mail.MessageListBox : Gtk.ListBox {
     }
 
     public void set_conversation (Camel.FolderThreadNode? node) {
-        // Prevent the user from interacting with the message thread while it
-        // is being reloaded. can_reply will be set to true after loading the
-        // thread.
+        /*
+         * Prevent the user from interacting with the message thread while it
+         * is being reloaded. can_reply will be set to true after loading the
+         * thread.
+         */
         can_reply = false;
         can_move_thread = false;
 
@@ -46,8 +48,10 @@ public class Mail.MessageListBox : Gtk.ListBox {
             return;
         }
 
-        // If there is a node, we can move the thread even without loading all
-        // individual messages.
+        /*
+         * If there is a node, we can move the thread even without loading all
+         * individual messages.
+         */
         can_move_thread = true;
 
         var item = new MessageListItem (node.message);


### PR DESCRIPTION
I've introduced a new property `can_move` which is similar to `can_reply` and determines whether the selected conversation can be moved. This branch only implements the case of moving a conversation to the trash, not to arbitrary branches.

Clicking the trash button while inside the trash folder does not do anything right now, so messages cannot be fully deleted right now.

I've had to disable selection of multiple conversations right now. I think the way to go would be to move & rename the `MessagesListBox.uids` property to `ConversationListBox.selected_uids`. Then both MessagesListBox and the MainWindow would figure out which messages are selected by looking at this property, and the MessagesListBox wouldn't have to deal with FolderThreadNode iteration at all.