### PR TITLE
Rewrite: Use newest timestamp in thread for thread timestamp

### DIFF
--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -32,12 +32,36 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
 
     public int64 timestamp {
         get {
+            int64 timestamp = 0;
             if (node.message.date_received == 0) {
                 // Sent messages do not have a date_received timestamp.
                 return node.message.date_sent;
+                timestamp = node.message.date_sent;
+
+                unowned Camel.FolderThreadNode? child = (Camel.FolderThreadNode?) node.child;
+                while (child != null) {
+                    if (child.message.date_sent > timestamp) {
+                        timestamp = child.message.date_sent;
+                    }
+
+                    child = (Camel.FolderThreadNode?) child.next;
+                }
+
+                return timestamp;
             }
 
             return node.message.date_received;
+            timestamp = node.message.date_received;
+            unowned Camel.FolderThreadNode? child = (Camel.FolderThreadNode?) node.child;
+            while (child != null) {
+                if (child.message.date_received > timestamp) {
+                    timestamp = child.message.date_received;
+                }
+
+                child = (Camel.FolderThreadNode?) child.next;
+            }
+
+            return timestamp;
         }
     }
 


### PR DESCRIPTION
In multi-message threads, it seems like the first message in the thread was being used to calculate the timestamp of that particular thread.

This PR takes whichever is the newest timestamp in the thread and uses that for the entire thread instead ensuring that threads with newer messages are sorted to the top.