### PR TITLE
ConversationListItem: Set use markup on source label

### DIFF
--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -53,6 +53,7 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
         source = new Gtk.Label (null);
         source.hexpand = true;
         source.ellipsize = Pango.EllipsizeMode.END;
+        source.use_markup = true;
         source.xalign = 0;
         source.get_style_context ().add_class ("h3");
 


### PR DESCRIPTION
Fixes an issue with markup being used in some sender names

![screenshot from 2018-10-17 15 34 46 2x](https://user-images.githubusercontent.com/7277719/47120177-97111400-d222-11e8-91bf-e178ee1ca11f.png)
