### PR TITLE
Change default and minimum window sizes

### DIFF
--- a/data/io.elementary.mail.gschema.xml
+++ b/data/io.elementary.mail.gschema.xml
@@ -3,7 +3,7 @@
   <schema path="/io/elementary/mail/"
   id="io.elementary.mail">
     <key name="window-height" type="i">
-      <default>-1</default>
+      <default>750</default>
       <summary>Most recent window height</summary>
       <description>Most recent window height</description>
     </key>
@@ -13,7 +13,7 @@
       <description>Whether the window was maximized on last run</description>
     </key>
     <key name="window-width" type="i">
-      <default>-1</default>
+      <default>1024</default>
       <summary>Most recent window width</summary>
       <description>Most recent window width</description>
     </key>
@@ -28,7 +28,7 @@
       <description>Most recent y position</description>
     </key> 
     <key name="paned-start-position" type="i">
-      <default>200</default>
+      <default>190</default>
       <summary>Most recent position of the folders pane</summary>
       <description>Most recent position of the folders pane</description>
     </key>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -61,12 +61,10 @@ public class Mail.Application : Gtk.Application {
                 main_window.move (window_x, window_y);
             }
 
-            if (window_height != -1 ||  window_width != -1) {
-                var rect = Gtk.Allocation ();
-                rect.height = window_height;
-                rect.width = window_width;
-                main_window.set_allocation (rect);
-            }
+            var rect = Gtk.Allocation ();
+            rect.height = window_height;
+            rect.width = window_width;
+            main_window.set_allocation (rect);
 
             if (settings.get_boolean ("window-maximized")) {
                 main_window.maximize ();
@@ -85,7 +83,6 @@ public class Mail.Application : Gtk.Application {
                 } else {
                     settings.set_boolean ("window-maximized", false);
 
-                    Gtk.Allocation rect;
                     main_window.get_allocation (out rect);
                     settings.set_int ("window-height", rect.height);
                     settings.set_int ("window-width", rect.width);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -46,9 +46,9 @@ public class Mail.MainWindow : Gtk.Window {
 
     public MainWindow () {
         Object (
-            height_request: 640,
+            height_request: 600,
             icon_name: "internet-mail",
-            width_request: 910
+            width_request: 800
         );
     }
 


### PR DESCRIPTION
* Make use of gsettings for setting the default window size and make this match the old default
* Make the sidebar width match Files
* Remove a now unnecessary check and re-use a rect
* Change the minimum size so that Mail can be tiled on a smaller laptop display. Fixes #173 