### PR TITLE
Add a welcome screen

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,6 +3,7 @@ src/HeaderBar.vala
 src/MainWindow.vala
 src/Utils.vala
 src/WebView.vala
+src/WelcomeView.vala
 src/Backend/Account.vala
 src/Backend/Session.vala
 src/Backend/ContactManager.vala

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -106,7 +106,46 @@ public class Mail.MainWindow : Gtk.Window {
         paned_end.pack1 (paned_start, false, false);
         paned_end.pack2 (view_overlay, true, true);
 
-        add (paned_end);
+        var welcome_icon = new Gtk.Image ();
+        welcome_icon.icon_name = "internet-mail";
+        welcome_icon.margin_bottom = 6;
+        welcome_icon.margin_end = 12;
+        welcome_icon.pixel_size = 64;
+
+        var welcome_badge = new Gtk.Image.from_icon_name ("preferences-desktop-online-accounts", Gtk.IconSize.DIALOG);
+        welcome_badge.halign = welcome_badge.valign = Gtk.Align.END;
+
+        var welcome_overlay = new Gtk.Overlay ();
+        welcome_overlay.halign = Gtk.Align.CENTER;
+        welcome_overlay.add (welcome_icon);
+        welcome_overlay.add_overlay (welcome_badge);
+
+        var welcome_title = new Gtk.Label (_("Connect An Email Account"));
+        welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
+
+        var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));
+        welcome_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+        var welcome_button = new Gtk.Button.with_label (_("Online Accounts…"));
+        welcome_button.halign = Gtk.Align.CENTER;
+        welcome_button.margin_top = 24;
+        welcome_button.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        welcome_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+        var welcome_grid = new Gtk.Grid ();
+        welcome_grid.halign = welcome_grid.valign = Gtk.Align.CENTER;
+        welcome_grid.orientation = Gtk.Orientation.VERTICAL;
+        welcome_grid.add (welcome_overlay);
+        welcome_grid.add (welcome_title);
+        welcome_grid.add (welcome_description);
+        welcome_grid.add (welcome_button);
+
+        var placeholder_stack = new Gtk.Stack ();
+        placeholder_stack.transition_type = Gtk.StackTransitionType.OVER_DOWN_UP;
+        placeholder_stack.add_named (paned_end, "mail");
+        placeholder_stack.add_named (welcome_grid, "welcome");
+
+        add (placeholder_stack);
 
         var settings = new GLib.Settings ("io.elementary.mail");
         settings.bind ("paned-start-position", paned_start, "position", SettingsBindFlags.DEFAULT);
@@ -132,6 +171,14 @@ public class Mail.MainWindow : Gtk.Window {
 
         paned_start.notify["position"].connect (() => {
             headerbar.set_paned_positions (paned_start.position, paned_end.position);
+        });
+
+        welcome_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+            } catch (Error e) {
+                warning (e.message);
+            }
         });
 
         Backend.Session.get_default ().start.begin ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -22,7 +22,7 @@ public class Mail.MainWindow : Gtk.Window {
     private HeaderBar headerbar;
     private Gtk.Paned paned_end;
     private Gtk.Paned paned_start;
-    
+
     private FoldersListView folders_list_view;
     private ConversationListBox conversation_list_box;
     private MessageListBox message_list_box;
@@ -120,7 +120,7 @@ public class Mail.MainWindow : Gtk.Window {
         welcome_overlay.add (welcome_icon);
         welcome_overlay.add_overlay (welcome_badge);
 
-        var welcome_title = new Gtk.Label (_("Connect An Email Account"));
+        var welcome_title = new Gtk.Label (_("Connect an Account"));
         welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
 
         var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -106,44 +106,12 @@ public class Mail.MainWindow : Gtk.Window {
         paned_end.pack1 (paned_start, false, false);
         paned_end.pack2 (view_overlay, true, true);
 
-        var welcome_icon = new Gtk.Image ();
-        welcome_icon.icon_name = "internet-mail";
-        welcome_icon.margin_bottom = 6;
-        welcome_icon.margin_end = 12;
-        welcome_icon.pixel_size = 64;
-
-        var welcome_badge = new Gtk.Image.from_icon_name ("preferences-desktop-online-accounts", Gtk.IconSize.DIALOG);
-        welcome_badge.halign = welcome_badge.valign = Gtk.Align.END;
-
-        var welcome_overlay = new Gtk.Overlay ();
-        welcome_overlay.halign = Gtk.Align.CENTER;
-        welcome_overlay.add (welcome_icon);
-        welcome_overlay.add_overlay (welcome_badge);
-
-        var welcome_title = new Gtk.Label (_("Connect an Account"));
-        welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
-
-        var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));
-        welcome_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
-
-        var welcome_button = new Gtk.Button.with_label (_("Online Accounts…"));
-        welcome_button.halign = Gtk.Align.CENTER;
-        welcome_button.margin_top = 24;
-        welcome_button.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
-        welcome_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-
-        var welcome_grid = new Gtk.Grid ();
-        welcome_grid.halign = welcome_grid.valign = Gtk.Align.CENTER;
-        welcome_grid.orientation = Gtk.Orientation.VERTICAL;
-        welcome_grid.add (welcome_overlay);
-        welcome_grid.add (welcome_title);
-        welcome_grid.add (welcome_description);
-        welcome_grid.add (welcome_button);
+        var welcome_view = new Mail.WelcomeView ();
 
         var placeholder_stack = new Gtk.Stack ();
         placeholder_stack.transition_type = Gtk.StackTransitionType.OVER_DOWN_UP;
         placeholder_stack.add_named (paned_end, "mail");
-        placeholder_stack.add_named (welcome_grid, "welcome");
+        placeholder_stack.add_named (welcome_view, "welcome");
 
         add (placeholder_stack);
 
@@ -173,15 +141,12 @@ public class Mail.MainWindow : Gtk.Window {
             headerbar.set_paned_positions (paned_start.position, paned_end.position);
         });
 
-        welcome_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
-            } catch (Error e) {
-                warning (e.message);
-            }
+        unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
+        session.account_added.connect (() => {
+            placeholder_stack.visible_child = paned_end;
         });
 
-        Backend.Session.get_default ().start.begin ();
+        session.start.begin ();
     }
 
     private void on_compose_message () {

--- a/src/WelcomeView.vala
+++ b/src/WelcomeView.vala
@@ -1,0 +1,68 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Corentin Noël <corentin@elementary.io>
+ */
+
+public class Mail.WelcomeView : Gtk.Grid {
+    construct {
+        halign = valign = Gtk.Align.CENTER;
+        orientation = Gtk.Orientation.VERTICAL;
+
+        var welcome_icon = new Gtk.Image ();
+        welcome_icon.icon_name = "internet-mail";
+        welcome_icon.margin_bottom = 6;
+        welcome_icon.margin_end = 12;
+        welcome_icon.pixel_size = 64;
+
+        var welcome_badge = new Gtk.Image.from_icon_name ("preferences-desktop-online-accounts", Gtk.IconSize.DIALOG);
+        welcome_badge.halign = welcome_badge.valign = Gtk.Align.END;
+
+        var welcome_overlay = new Gtk.Overlay ();
+        welcome_overlay.halign = Gtk.Align.CENTER;
+        welcome_overlay.add (welcome_icon);
+        welcome_overlay.add_overlay (welcome_badge);
+
+        var welcome_title = new Gtk.Label (_("Connect an Account"));
+        welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
+
+        var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));
+        welcome_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+        var welcome_button = new Gtk.Button.with_label (_("Online Accounts…"));
+        weak Gtk.StyleContext welcome_button_style_context = welcome_button.get_style_context ();
+        welcome_button.halign = Gtk.Align.CENTER;
+        welcome_button.margin_top = 24;
+        welcome_button_style_context.add_class (Granite.STYLE_CLASS_H3_LABEL);
+        welcome_button_style_context.add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+        add (welcome_overlay);
+        add (welcome_title);
+        add (welcome_description);
+        add (welcome_button);
+
+        welcome_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+            } catch (Error e) {
+                critical (e.message);
+            }
+        });
+
+        show_all ();
+    }
+}

--- a/src/WelcomeView.vala
+++ b/src/WelcomeView.vala
@@ -38,9 +38,13 @@ public class Mail.WelcomeView : Gtk.Grid {
         welcome_overlay.add_overlay (welcome_badge);
 
         var welcome_title = new Gtk.Label (_("Connect an Account"));
+        welcome_title.wrap = true;
+        welcome_title.max_width_chars = 70;
         welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
 
         var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));
+        welcome_description.wrap = true;
+        welcome_description.max_width_chars = 70;
         welcome_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var welcome_button = new Gtk.Button.with_label (_("Online Accounts…"));

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ vala_files = [
     'Dialogs/OpenAttachmentDialog.vala',
     'Utils.vala',
     'WebView.vala',
+    'WelcomeView.vala',
     'Backend/Session.vala',
     'Backend/Account.vala',
     'Backend/ContactManager.vala',


### PR DESCRIPTION
Adds a welcome screen that links to Online Accounts.

Need to add a signal listener to show/hide the appropriate screen depending on if accounts are configured in EDS.

![screenshot from 2018-10-22 21 36 36 2x](https://user-images.githubusercontent.com/7277719/47336304-02ece580-d644-11e8-8ead-db06085d0258.png)
