### PR TITLE
Set tooltip accel markup

### DIFF
--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -146,25 +146,25 @@ public class Mail.ComposerWidget : Gtk.Grid {
         }
 
         var bold = new Gtk.ToggleButton ();
-        bold.tooltip_text = _("Bold (Ctrl+B)");
+        bold.tooltip_markup = Granite.markup_accel_tooltip (_("Bold"), {"<Ctrl>B"});
         bold.image = new Gtk.Image.from_icon_name ("format-text-bold-symbolic", Gtk.IconSize.MENU);
         bold.action_name = ACTION_PREFIX + ACTION_BOLD;
         bold.action_target = ACTION_BOLD;
 
         var italic = new Gtk.ToggleButton ();
-        italic.tooltip_text = _("Italic (Ctrl+I)");
+        italic.tooltip_markup = Granite.markup_accel_tooltip (_("Italic"), {"<Ctrl>I"});
         italic.image = new Gtk.Image.from_icon_name ("format-text-italic-symbolic", Gtk.IconSize.MENU);
         italic.action_name = ACTION_PREFIX + ACTION_ITALIC;
         italic.action_target = ACTION_ITALIC;
 
         var underline = new Gtk.ToggleButton ();
-        underline.tooltip_text = _("Underline (Ctrl+U)");
+        underline.tooltip_markup = Granite.markup_accel_tooltip (_("Underline"), {"<Ctrl>U"});
         underline.image = new Gtk.Image.from_icon_name ("format-text-underline-symbolic", Gtk.IconSize.MENU);
         underline.action_name = ACTION_PREFIX + ACTION_UNDERLINE;
         underline.action_target = ACTION_UNDERLINE;
 
         var strikethrough = new Gtk.ToggleButton ();
-        strikethrough.tooltip_text = _("Strikethrough (Ctrl+%)");
+        strikethrough.tooltip_markup = Granite.markup_accel_tooltip (_("Strikethrough"), {"<Ctrl>percent"});
         strikethrough.image = new Gtk.Image.from_icon_name ("format-text-strikethrough-symbolic", Gtk.IconSize.MENU);
         strikethrough.action_name = ACTION_PREFIX + ACTION_STRIKETHROUGH;
         strikethrough.action_target = ACTION_STRIKETHROUGH;
@@ -177,10 +177,10 @@ public class Mail.ComposerWidget : Gtk.Grid {
         formatting_buttons.add (strikethrough);
 
         var indent_more = new Gtk.Button.from_icon_name ("format-indent-more-symbolic", Gtk.IconSize.MENU);
-        indent_more.tooltip_text = _("Quote text (Ctrl+])");
+        indent_more.tooltip_markup = Granite.markup_accel_tooltip (_("Quote text"), {"<Ctrl>bracketright"});
 
         var indent_less = new Gtk.Button.from_icon_name ("format-indent-less-symbolic", Gtk.IconSize.MENU);
-        indent_less.tooltip_text = _("Unquote text (Ctrl+[)");
+        indent_less.tooltip_markup = Granite.markup_accel_tooltip (_("Unquote text"), {"<Ctrl>bracketleft"});
 
         var indent_buttons = new Gtk.Grid ();
         indent_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
@@ -188,13 +188,13 @@ public class Mail.ComposerWidget : Gtk.Grid {
         indent_buttons.add (indent_less);
 
         var link = new Gtk.Button.from_icon_name ("insert-link-symbolic", Gtk.IconSize.MENU);
-        link.tooltip_text = _("Link (Ctrl+K)");
+        link.tooltip_markup = Granite.markup_accel_tooltip (_("Insert Link"), {"<Ctrl>K"});
 
         var image = new Gtk.Button.from_icon_name ("insert-image-symbolic", Gtk.IconSize.MENU);
-        image.tooltip_text = _("Image (Ctrl+G)");
+        image.tooltip_markup = Granite.markup_accel_tooltip (_("Insert Image"), {"<Ctrl>G"});
 
         var clear_format = new Gtk.Button.from_icon_name ("format-text-clear-formatting-symbolic", Gtk.IconSize.MENU);
-        clear_format.tooltip_text = _("Remove formatting (Ctrl+Space)");
+        clear_format.tooltip_markup = Granite.markup_accel_tooltip (_("Remove formatting"), {"<Ctrl>space"});
         clear_format.action_name = ACTION_PREFIX + ACTION_REMOVE_FORMAT;
 
         var button_row = new Gtk.Grid ();
@@ -233,7 +233,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
         send.sensitive = false;
         send.always_show_image = true;
         send.label = _("Send");
-        send.tooltip_text = _("Send (Ctrl+Enter)");
+        send.tooltip_markup = Granite.markup_accel_tooltip (_("Send"), {"<Ctrl>ISO_Enter"});
         send.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
         action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -146,25 +146,25 @@ public class Mail.ComposerWidget : Gtk.Grid {
         }
 
         var bold = new Gtk.ToggleButton ();
-        bold.tooltip_markup = Granite.markup_accel_tooltip (_("Bold"), {"<Ctrl>B"});
+        bold.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>B"}, _("Bold"));
         bold.image = new Gtk.Image.from_icon_name ("format-text-bold-symbolic", Gtk.IconSize.MENU);
         bold.action_name = ACTION_PREFIX + ACTION_BOLD;
         bold.action_target = ACTION_BOLD;
 
         var italic = new Gtk.ToggleButton ();
-        italic.tooltip_markup = Granite.markup_accel_tooltip (_("Italic"), {"<Ctrl>I"});
+        italic.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>I"}, _("Italic"));
         italic.image = new Gtk.Image.from_icon_name ("format-text-italic-symbolic", Gtk.IconSize.MENU);
         italic.action_name = ACTION_PREFIX + ACTION_ITALIC;
         italic.action_target = ACTION_ITALIC;
 
         var underline = new Gtk.ToggleButton ();
-        underline.tooltip_markup = Granite.markup_accel_tooltip (_("Underline"), {"<Ctrl>U"});
+        underline.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>U"}, _("Underline"));
         underline.image = new Gtk.Image.from_icon_name ("format-text-underline-symbolic", Gtk.IconSize.MENU);
         underline.action_name = ACTION_PREFIX + ACTION_UNDERLINE;
         underline.action_target = ACTION_UNDERLINE;
 
         var strikethrough = new Gtk.ToggleButton ();
-        strikethrough.tooltip_markup = Granite.markup_accel_tooltip (_("Strikethrough"), {"<Ctrl>percent"});
+        strikethrough.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>percent"}, _("Strikethrough"));
         strikethrough.image = new Gtk.Image.from_icon_name ("format-text-strikethrough-symbolic", Gtk.IconSize.MENU);
         strikethrough.action_name = ACTION_PREFIX + ACTION_STRIKETHROUGH;
         strikethrough.action_target = ACTION_STRIKETHROUGH;
@@ -177,10 +177,10 @@ public class Mail.ComposerWidget : Gtk.Grid {
         formatting_buttons.add (strikethrough);
 
         var indent_more = new Gtk.Button.from_icon_name ("format-indent-more-symbolic", Gtk.IconSize.MENU);
-        indent_more.tooltip_markup = Granite.markup_accel_tooltip (_("Quote text"), {"<Ctrl>bracketright"});
+        indent_more.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>bracketright"}, _("Quote text"));
 
         var indent_less = new Gtk.Button.from_icon_name ("format-indent-less-symbolic", Gtk.IconSize.MENU);
-        indent_less.tooltip_markup = Granite.markup_accel_tooltip (_("Unquote text"), {"<Ctrl>bracketleft"});
+        indent_less.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>bracketleft"}, _("Unquote text"));
 
         var indent_buttons = new Gtk.Grid ();
         indent_buttons.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
@@ -188,13 +188,13 @@ public class Mail.ComposerWidget : Gtk.Grid {
         indent_buttons.add (indent_less);
 
         var link = new Gtk.Button.from_icon_name ("insert-link-symbolic", Gtk.IconSize.MENU);
-        link.tooltip_markup = Granite.markup_accel_tooltip (_("Insert Link"), {"<Ctrl>K"});
+        link.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>K"}, _("Insert Link"));
 
         var image = new Gtk.Button.from_icon_name ("insert-image-symbolic", Gtk.IconSize.MENU);
-        image.tooltip_markup = Granite.markup_accel_tooltip (_("Insert Image"), {"<Ctrl>G"});
+        image.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>G"}, _("Insert Image"));
 
         var clear_format = new Gtk.Button.from_icon_name ("format-text-clear-formatting-symbolic", Gtk.IconSize.MENU);
-        clear_format.tooltip_markup = Granite.markup_accel_tooltip (_("Remove formatting"), {"<Ctrl>space"});
+        clear_format.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>space"}, _("Remove formatting"));
         clear_format.action_name = ACTION_PREFIX + ACTION_REMOVE_FORMAT;
 
         var button_row = new Gtk.Grid ();
@@ -233,7 +233,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
         send.sensitive = false;
         send.always_show_image = true;
         send.label = _("Send");
-        send.tooltip_markup = Granite.markup_accel_tooltip (_("Send"), {"<Ctrl>ISO_Enter"});
+        send.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>ISO_Enter"});
         send.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
         action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -53,6 +53,7 @@ public class Mail.ConversationListItem : Gtk.ListBoxRow {
         source = new Gtk.Label (null);
         source.hexpand = true;
         source.ellipsize = Pango.EllipsizeMode.END;
+        source.use_markup = true;
         source.xalign = 0;
         source.get_style_context ().add_class ("h3");
 

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -30,7 +30,7 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
     construct {
         var compose_button = new Gtk.Button.from_icon_name ("mail-message-new", Gtk.IconSize.LARGE_TOOLBAR);
         compose_button.halign = Gtk.Align.START;
-        compose_button.tooltip_text = _("Compose new message (Ctrl+N, N)");
+        compose_button.tooltip_markup = markup_accel_tooltip (_("Compose new message"), "Ctrl + N");
         compose_button.action_name = "win." + MainWindow.ACTION_COMPOSE_MESSAGE;
 
         spacing_widget = new Gtk.Grid ();
@@ -79,19 +79,19 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         app_menu.tooltip_text = _("Menu");
 
         var reply_button = new Gtk.Button.from_icon_name ("mail-reply-sender", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_button.tooltip_text = _("Reply (Ctrl+R, R)");
+        reply_button.tooltip_markup = markup_accel_tooltip (_("Reply"), "Ctrl + R");
         reply_button.action_name = "win." + MainWindow.ACTION_REPLY;
 
         var reply_all_button = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_all_button.tooltip_text = _("Reply All (Ctrl+Shift+R, Shift+R)");
+        reply_all_button.tooltip_markup = markup_accel_tooltip (_("Reply All"), "Ctrl + Shift + R");
         reply_all_button.action_name = "win." + MainWindow.ACTION_REPLY_ALL;
 
         var forward_button = new Gtk.Button.from_icon_name ("mail-forward", Gtk.IconSize.LARGE_TOOLBAR);
-        forward_button.tooltip_text = _("Forward (Ctrl+Shift+F)");
+        forward_button.tooltip_markup = markup_accel_tooltip (_("Forward"), "Ctrl + Shift + F");
         forward_button.action_name = "win." + MainWindow.ACTION_FORWARD;
 
         var trash_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
-        trash_button.tooltip_text = _("Move conversations to Trash (Delete, Backspace)");
+        trash_button.tooltip_markup = markup_accel_tooltip (_("Move conversations to Trash"), "Delete, Backspace");
         trash_button.action_name = "win." + MainWindow.ACTION_MOVE_TO_TRASH;
 
         pack_start (compose_button);
@@ -115,6 +115,10 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         load_images_menuitem.clicked.connect (() => {
             load_images_switch.activate ();
         });
+    }
+
+    private string markup_accel_tooltip (string tooltip_text, string accel) {
+        return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (tooltip_text, accel);
     }
 
     public void set_paned_positions (int start_position, int end_position, bool start_changed = true) {

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -30,7 +30,7 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
     construct {
         var compose_button = new Gtk.Button.from_icon_name ("mail-message-new", Gtk.IconSize.LARGE_TOOLBAR);
         compose_button.halign = Gtk.Align.START;
-        compose_button.tooltip_markup = markup_accel_tooltip (_("Compose new message"), "Ctrl + N");
+        compose_button.tooltip_markup = Granite.markup_accel_tooltip (_("Compose new message"), {"<Ctrl>N"});
         compose_button.action_name = "win." + MainWindow.ACTION_COMPOSE_MESSAGE;
 
         spacing_widget = new Gtk.Grid ();
@@ -79,19 +79,19 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         app_menu.tooltip_text = _("Menu");
 
         var reply_button = new Gtk.Button.from_icon_name ("mail-reply-sender", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_button.tooltip_markup = markup_accel_tooltip (_("Reply"), "Ctrl + R");
+        reply_button.tooltip_markup = Granite.markup_accel_tooltip (_("Reply"), {"<Ctrl>R"});
         reply_button.action_name = "win." + MainWindow.ACTION_REPLY;
 
         var reply_all_button = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_all_button.tooltip_markup = markup_accel_tooltip (_("Reply All"), "Ctrl + Shift + R");
+        reply_all_button.tooltip_markup = Granite.markup_accel_tooltip (_("Reply All"), {"<Ctrl><Shift>R"});
         reply_all_button.action_name = "win." + MainWindow.ACTION_REPLY_ALL;
 
         var forward_button = new Gtk.Button.from_icon_name ("mail-forward", Gtk.IconSize.LARGE_TOOLBAR);
-        forward_button.tooltip_markup = markup_accel_tooltip (_("Forward"), "Ctrl + Shift + F");
+        forward_button.tooltip_markup = Granite.markup_accel_tooltip (_("Forward"), {"<Ctrl><Shift>F"});
         forward_button.action_name = "win." + MainWindow.ACTION_FORWARD;
 
         var trash_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
-        trash_button.tooltip_markup = markup_accel_tooltip (_("Move conversations to Trash"), "Delete, Backspace");
+        trash_button.tooltip_markup = Granite.markup_accel_tooltip (_("Move conversations to Trash"), {"Delete", "BackSpace"});
         trash_button.action_name = "win." + MainWindow.ACTION_MOVE_TO_TRASH;
 
         pack_start (compose_button);
@@ -115,10 +115,6 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         load_images_menuitem.clicked.connect (() => {
             load_images_switch.activate ();
         });
-    }
-
-    private string markup_accel_tooltip (string tooltip_text, string accel) {
-        return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (tooltip_text, accel);
     }
 
     public void set_paned_positions (int start_position, int end_position, bool start_changed = true) {

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -30,7 +30,7 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
     construct {
         var compose_button = new Gtk.Button.from_icon_name ("mail-message-new", Gtk.IconSize.LARGE_TOOLBAR);
         compose_button.halign = Gtk.Align.START;
-        compose_button.tooltip_markup = Granite.markup_accel_tooltip (_("Compose new message"), {"<Ctrl>N"});
+        compose_button.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>N"}, _("Compose new message"));
         compose_button.action_name = "win." + MainWindow.ACTION_COMPOSE_MESSAGE;
 
         spacing_widget = new Gtk.Grid ();
@@ -79,19 +79,19 @@ public class Mail.HeaderBar : Gtk.HeaderBar {
         app_menu.tooltip_text = _("Menu");
 
         var reply_button = new Gtk.Button.from_icon_name ("mail-reply-sender", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_button.tooltip_markup = Granite.markup_accel_tooltip (_("Reply"), {"<Ctrl>R"});
+        reply_button.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl>R"}, _("Reply"));
         reply_button.action_name = "win." + MainWindow.ACTION_REPLY;
 
         var reply_all_button = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        reply_all_button.tooltip_markup = Granite.markup_accel_tooltip (_("Reply All"), {"<Ctrl><Shift>R"});
+        reply_all_button.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl><Shift>R"}, _("Reply All"));
         reply_all_button.action_name = "win." + MainWindow.ACTION_REPLY_ALL;
 
         var forward_button = new Gtk.Button.from_icon_name ("mail-forward", Gtk.IconSize.LARGE_TOOLBAR);
-        forward_button.tooltip_markup = Granite.markup_accel_tooltip (_("Forward"), {"<Ctrl><Shift>F"});
+        forward_button.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"<Ctrl><Shift>F"}, _("Forward"));
         forward_button.action_name = "win." + MainWindow.ACTION_FORWARD;
 
         var trash_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
-        trash_button.tooltip_markup = Granite.markup_accel_tooltip (_("Move conversations to Trash"), {"Delete", "BackSpace"});
+        trash_button.tooltip_markup = Mail.Utils.markup_accel_tooltip ({"Delete", "BackSpace"}, _("Move conversations to Trash"));
         trash_button.action_name = "win." + MainWindow.ACTION_MOVE_TO_TRASH;
 
         pack_start (compose_button);

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -61,4 +61,64 @@ public class Mail.Utils {
     public static string escape_html_tags (string input) {
         return input.replace ("<", "&lt;").replace (">", "&gt;");
     }
+
+    private static string accel_to_string (string accel) {
+        uint accel_key;
+        Gdk.ModifierType accel_mods;
+        Gtk.accelerator_parse (accel, out accel_key, out accel_mods);
+
+        string[] arr = {};
+        if (Gdk.ModifierType.SUPER_MASK in accel_mods) {
+            arr += "⌘";
+        }
+
+        if (Gdk.ModifierType.SHIFT_MASK in accel_mods) {
+            arr += _("Shift");
+        }
+
+        if (Gdk.ModifierType.CONTROL_MASK in accel_mods) {
+            arr += _("Ctrl");
+        }
+
+        if (Gdk.ModifierType.MOD1_MASK in accel_mods) {
+            arr += _("Alt");
+        }
+
+        switch (accel_key) {
+            case Gdk.Key.Up:
+                arr += "↑";
+                break;
+            case Gdk.Key.Down:
+                arr += "↓";
+                break;
+            case Gdk.Key.Left:
+                arr += "←";
+                break;
+            case Gdk.Key.Right:
+                arr += "→";
+                break;
+            default:
+                arr += Gtk.accelerator_get_label (accel_key, 0);
+                break;
+        }
+
+        return string.joinv (" + ", arr);
+    }
+
+    public static string markup_accel_tooltip (string[] accels, string? description = null) {
+        for (int i = 0; i < accels.length; i++) {
+            accels[i] = accel_to_string (accels[i]); 
+        }
+
+        ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
+        var accel_label = string.joinv (_(", "), accels);
+
+        var markup = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
+
+        if (description != null && description != "") {
+            markup = string.join ("\n", description, markup);
+        }
+
+        return markup;
+    }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -62,6 +62,7 @@ public class Mail.Utils {
         return input.replace ("<", "&lt;").replace (">", "&gt;");
     }
 
+    //FIXME: Remove this util when Granite 5.2 is released.
     private static string accel_to_string (string accel) {
         uint accel_key;
         Gdk.ModifierType accel_mods;
@@ -105,6 +106,7 @@ public class Mail.Utils {
         return string.joinv (" + ", arr);
     }
 
+    //FIXME: Remove this util when Granite 5.2 is released.
     public static string markup_accel_tooltip (string[] accels, string? description = null) {
         for (int i = 0; i < accels.length; i++) {
             accels[i] = accel_to_string (accels[i]); 


### PR DESCRIPTION
Uses the new tooltip markup style that we discussed this morning in #UX 

![screenshot from 2018-10-23 10 13 26 2x](https://user-images.githubusercontent.com/7277719/47378360-bb4e7400-d6ac-11e8-8457-298eebbbff76.png)

I've temporarily added two utils that were recently merged into granite [here](https://github.com/elementary/granite/commit/07afa7ac0cbdf1d6dd923d5392722c54665af0c5). I figure we can easily remove those utils once a new Granite release comes out.
