### PR TITLE
Add travis file for Houston CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+---
+
+language: node_js
+
+node_js:
+  - lts/*
+
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-5-dev
+
+install:
+  - npm i -g @elementaryos/houston
+
+script:
+  - houston ci
+    --type system-app
+    --name-domain io.elementary.mail
+    --name-human Mail


### PR DESCRIPTION
Had to rename `deb-packaging-1.x` branch to `1.x-deb-packaging` as that was getting prioritized over the `deb-packaging` branch we needed.