### PR TITLE
Bind composer action sensitivity to web view focus

### DIFF
--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -256,6 +256,12 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
         bind_property ("has-recipients", send, "sensitive");
 
+        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_BOLD), "enabled", BindingFlags.SYNC_CREATE);
+        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_ITALIC), "enabled", BindingFlags.SYNC_CREATE);
+        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_UNDERLINE), "enabled", BindingFlags.SYNC_CREATE);
+        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_STRIKETHROUGH), "enabled", BindingFlags.SYNC_CREATE);
+        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_REMOVE_FORMAT), "enabled", BindingFlags.SYNC_CREATE);
+
         cc_button.clicked.connect (() => {
             cc_revealer.reveal_child = cc_button.active;
         });


### PR DESCRIPTION
I think all actions above the web view are expected to do something with the selection in the webview or at least at the current cursor position of the webview, so make sure we only enable them when there's a cursor in there.