### PR TITLE
Revert #310

### DIFF
--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -256,12 +256,6 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
         bind_property ("has-recipients", send, "sensitive");
 
-        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_BOLD), "enabled", BindingFlags.SYNC_CREATE);
-        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_ITALIC), "enabled", BindingFlags.SYNC_CREATE);
-        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_UNDERLINE), "enabled", BindingFlags.SYNC_CREATE);
-        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_STRIKETHROUGH), "enabled", BindingFlags.SYNC_CREATE);
-        web_view.bind_property ("has-focus", actions.lookup_action (ACTION_REMOVE_FORMAT), "enabled", BindingFlags.SYNC_CREATE);
-
         cc_button.clicked.connect (() => {
             cc_revealer.reveal_child = cc_button.active;
         });


### PR DESCRIPTION
Seems like this change wasn't actually tested. This makes it impossible to activate any of these actions since clicking any of the toolitems necessarily moves focus but it also makes it impossible to use keyboard navigation to activate any of the toolitems.

Some of these items should probably be insensitive when there is no selection in the webview, but checking focus makes it unusable