### PR TITLE
Application: Make restore state code more concise

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -57,17 +57,15 @@ public class Mail.Application : Gtk.Application {
             main_window = new MainWindow ();
 
             int window_x, window_y;
+            var rect = Gtk.Allocation ();
+
             settings.get ("window-position", "(ii)", out window_x, out window_y);
+            settings.get ("window-size", "(ii)", out rect.width, out rect.height);
 
             if (window_x != -1 ||  window_y != -1) {
                 main_window.move (window_x, window_y);
             }
 
-            int window_width, window_height;
-            settings.get ("window-size", "(ii)", out window_width, out window_height);
-            var rect = Gtk.Allocation ();
-            rect.width = window_width;
-            rect.height = window_height;
             main_window.set_allocation (rect);
 
             if (settings.get_boolean ("window-maximized")) {


### PR DESCRIPTION
Gets rid of a couple extra variables and write directly to the allocation rectangle