### PR TITLE
Add account instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ To install, use `ninja install`, then execute with `io.elementary.mail`
     io.elementary.mail
 
 You might want to set the `WEBKIT_EXTENSION_PATH` environment variable to the `webkit-extension` build folder in order to test the application without installing it
+
+## Connecting Your Account
+
+Mail uses Evolution Data Server and Camel to display your emails. Currently, the easiset way to test Mail with your accounts is to set up them up in Evolution first. Ultimately, setting up an account in Online Accounts will connect it to EDS/Camel but that has not yet been implemented.


### PR DESCRIPTION
Since I've heard a few people asking how to help test, and according to the UI it looks like the Online Accounts integration should just work. This can be removed from the README once setting up and Online Account actually makes email accounts accessible to Camel/EDS.