### PR TITLE
Pull to Refresh

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -35,6 +35,7 @@ public class Mail.ConversationListBox : Gtk.ListBox {
     construct {
         activate_on_single_click = true;
         conversations = new Gee.HashMap<string, ConversationListItem> ();
+        set_header_func (thread_header_function);
         set_sort_func (thread_sort_function);
         row_activated.connect ((row) => {
             if (row == null) {
@@ -133,5 +134,42 @@ public class Mail.ConversationListBox : Gtk.ListBox {
         var item1 = (ConversationListItem) row1;
         var item2 = (ConversationListItem) row2;
         return (int)(item2.timestamp - item1.timestamp);
+    }
+
+    private static void thread_header_function (Gtk.ListBoxRow row1, Gtk.ListBoxRow? row2) {
+        var item1 = (ConversationListItem) row1;
+        var item2 = (ConversationListItem) row2;
+
+        int64 item2_timestamp;
+        if (item2 != null) {
+            item2_timestamp = item2.timestamp;
+        } else {
+            item2_timestamp = 0;
+        }
+
+        if (item2_timestamp - item1.timestamp < 0) {
+            var loading_label = new Gtk.Label (_("Updating…"));
+            loading_label.halign = Gtk.Align.START;
+            loading_label.valign = Gtk.Align.CENTER;
+            loading_label.hexpand = loading_label.vexpand = true;
+
+            var spinner = new Gtk.Spinner ();
+            spinner.active = true;
+            spinner.halign = Gtk.Align.END;
+            spinner.valign = Gtk.Align.CENTER;
+            spinner.hexpand = spinner.vexpand = true;
+
+            var pull_to_refresh = new Gtk.Grid ();
+            pull_to_refresh.column_spacing = 6;
+            pull_to_refresh.height_request = 64;
+            pull_to_refresh.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
+            pull_to_refresh.add (spinner);
+            pull_to_refresh.add (loading_label);
+            pull_to_refresh.show_all ();
+
+            row1.set_header (pull_to_refresh);
+        } else {
+            row1.set_header (null); 
+        }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -147,6 +147,23 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
             message_list_box.set_conversation (node);
         });
 
+        conversation_list_scrolled.size_allocate.connect (() => {
+            var adjustment = conversation_list_scrolled.vadjustment;
+
+            var val1 = adjustment.value;
+            double val2;
+            GLib.Timeout.add (8, () => {
+                val2 = adjustment.value;
+                if (val1 == val2 && val2 < 64){
+                    if (val2 < 8) {
+                        adjustment.set_value (val2 + 1);
+                    } else {
+                        adjustment.set_value (val2 + 8);
+                    }
+                }
+            });
+        });
+
         headerbar.size_allocate.connect (() => {
             headerbar.set_paned_positions (paned_start.position, paned_end.position);
         });


### PR DESCRIPTION
Fixes #38 

- [ ] Doesn't actually request a refresh
- [ ] Contents should probably change between the being-pulled state and after having been pulled. (Ex. "↓ Last updated 10m ago" ⇒ "⌚ Updating…"
- [ ] Stutters when pulling slowly
- [ ] Stutters at the top of the pull
- [ ] Probably want to remove overshoot CSS since it kind of conflicts
- [ ] Should scroll to the size of the header grid instead of using magic numbers

Right now I'm using a timeout to try and guess if the user is scrolling or not which is why there's all this garbage stuttering. What we need to do instead is probably listen to the scroll event signal and make sure we're only trying to animate back when that's false