### PR TITLE
ConversationListItem: Make sure we hide status when appropriate

### DIFF
--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -104,6 +104,8 @@ public class Mail.ConversationListItem : VirtualizingListBoxRow {
             } else if (data.forwarded) {
                 status_icon.icon_name = "go-next-symbolic";
                 status_revealer.reveal_child = true;
+            } else {
+                status_revealer.reveal_child = false;
             }
         }
 


### PR DESCRIPTION
This fixes an issue where sometimes we'd have little black unread icons next to read emails