### PR TITLE
MessageListItem: Parse message_info.from into a linkbutton

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -88,9 +88,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         subject_label.valign = Gtk.Align.START;
         subject_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        var from_val_label = new Gtk.Label (message_info.from);
-        from_val_label.wrap = true;
-        from_val_label.xalign = 0;
+        var from_individualitem = new IndividualItem (message_info.from);
 
         var to_val_label = new Gtk.Label (message_info.to);
         to_val_label.wrap = true;
@@ -106,7 +104,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         fields_grid.attach (from_label, 0, 0, 1, 1);
         fields_grid.attach (to_label, 0, 1, 1, 1);
         fields_grid.attach (subject_label, 0, 3, 1, 1);
-        fields_grid.attach (from_val_label, 1, 0, 1, 1);
+        fields_grid.attach (from_individualitem, 1, 0);
         fields_grid.attach (to_val_label, 1, 1, 1, 1);
         fields_grid.attach (subject_val_label, 1, 3, 1, 1);
 
@@ -125,9 +123,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             fields_grid.attach (cc_val_label, 1, 2, 1, 1);
         }
 
-        var small_from_label = new Gtk.Label (message_info.from);
-        from_val_label.ellipsize = Pango.EllipsizeMode.END;
-        from_val_label.xalign = 0;
+        var small_from_label = new IndividualItem (message_info.from);
 
         var small_fields_grid = new Gtk.Grid ();
         small_fields_grid.attach (small_from_label, 0, 0, 1, 1);
@@ -461,5 +457,39 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
     public string get_message_body_html () {
         return web_view.get_body_html ();
+    }
+
+    private class IndividualItem : Gtk.Button {
+        public string message_info_from { get; construct; }
+
+        public IndividualItem (string message_info_from) {
+            Object (message_info_from: message_info_from);
+        }
+
+        construct {
+            string[] parsed_from = message_info_from.replace (">", "").split ("<");
+
+            var display_name_label = new Gtk.Label (parsed_from[0]);
+            display_name_label.wrap = true;
+            display_name_label.tooltip_text = parsed_from[1];
+
+            halign = Gtk.Align.START;
+            add (display_name_label);
+
+            var style_context = get_style_context ();
+            style_context.add_class (Gtk.STYLE_CLASS_FLAT);
+            style_context.add_class ("link");
+
+            /* Connecting to clicked () doesn't allow us to prevent the event from propagating to header_event_box */
+            button_release_event.connect (() => {
+                try {
+                    AppInfo.launch_default_for_uri ("mailto:" + parsed_from[1], null);
+                } catch (Error e) {
+                    warning ("Failed to open mailto link: %s", e.message);
+                }
+
+                return Gdk.EVENT_STOP;
+            });
+        }
     }
 }


### PR DESCRIPTION
Replaces the dumb label with a link style button that opens a mailto link, just like Mail 1.x did