### PR TITLE
Full screen support

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -22,6 +22,7 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
     private HeaderBar headerbar;
     private Gtk.Paned paned_end;
     private Gtk.Paned paned_start;
+    private Gtk.Grid container_grid;
 
     private FoldersListView folders_list_view;
     private Gtk.Overlay conversation_list_overlay;
@@ -40,6 +41,7 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
     public const string ACTION_MARK_READ = "mark-read";
     public const string ACTION_MARK_UNREAD = "mark-unread";
     public const string ACTION_MOVE_TO_TRASH = "trash";
+    public const string ACTION_FULLSCREEN = "full-screen";
 
     private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -51,6 +53,7 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
         {ACTION_MARK_READ,          on_mark_read         },
         {ACTION_MARK_UNREAD,        on_mark_unread       },
         {ACTION_MOVE_TO_TRASH,      on_move_to_trash     },
+        {ACTION_FULLSCREEN,         on_fullscreen        },
     };
 
     public MainWindow (Gtk.Application application) {
@@ -71,6 +74,7 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
         action_accelerators[ACTION_MARK_UNREAD] = "<Ctrl><Shift>u";
         action_accelerators[ACTION_MOVE_TO_TRASH] = "Delete";
         action_accelerators[ACTION_MOVE_TO_TRASH] = "BackSpace";
+        action_accelerators[ACTION_FULLSCREEN] = "F11";
     }
 
     construct {
@@ -142,7 +146,9 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
         placeholder_stack.add_named (paned_end, "mail");
         placeholder_stack.add_named (welcome_view, "welcome");
 
-        add (placeholder_stack);
+        container_grid = new Gtk.Grid ();
+        container_grid.attach (placeholder_stack, 0, 1, 1, 1);
+        add (container_grid);
 
         var settings = new GLib.Settings ("io.elementary.mail");
         settings.bind ("paned-start-position", paned_start, "position", SettingsBindFlags.DEFAULT);
@@ -242,6 +248,20 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
 
             conversation_list_overlay.add_overlay (toast);
             toast.send_notification ();
+        }
+    }
+
+    private void on_fullscreen () {
+		if ((get_window ().get_state () & Gdk.WindowState.FULLSCREEN) != 0) {
+            container_grid.remove (headerbar);
+            set_titlebar (headerbar);
+            headerbar.show_close_button = true;
+            unfullscreen ();
+        } else {
+            remove (headerbar);
+            container_grid.attach (headerbar, 0, 0, 1, 1);
+            headerbar.show_close_button = false;
+            fullscreen ();
         }
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -252,7 +252,7 @@ public class Mail.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void on_fullscreen () {
-		if ((get_window ().get_state () & Gdk.WindowState.FULLSCREEN) != 0) {
+		if (Gdk.WindowState.FULLSCREEN in get_window ().get_state ()) {
             container_grid.remove (headerbar);
             set_titlebar (headerbar);
             headerbar.show_close_button = true;


### PR DESCRIPTION
Hello! I liked how Terminal, Code, Epiphany supported true full screen and wanted to have the same with Mail. I use full screen on many of my applications so it's easy to switch using workspaces and have it feel like the entire workspace is dedicated to just that app.

I am not sure if the HIG says that the `HeaderBar` should not be visible when in full screen mode (I noticed it is hidden on Code and Epihany), but core functionality was hidden away so I made the `HeaderBar` visible in full screen mode in my PR.

![Full screen Mail](https://user-images.githubusercontent.com/1065321/54093074-4af17800-4359-11e9-9fce-677756e571a0.png)
