### PR TITLE
#389 don't assume left-to-right text ordering

### DIFF
--- a/data/blank-message-template.html
+++ b/data/blank-message-template.html
@@ -48,6 +48,6 @@
     </style>
 </head>
 <body>
-    <div contenteditable="true" id="message-body"></div>
+    <div contenteditable="true" id="message-body" dir="auto"></div>
 </body>
 </html>


### PR DESCRIPTION
Cribbing from Geary here, to use the `dir="auto"` attribute on the containing `div` in the composer web view. This uses the "first strong" heuristic: the first letter in the text with a clear directionality determines the overall text direction. One _could_ get more clever, but even Apple Mail uses this simple rule.

Note that the subject field, and probably other native text widgets, already handle bidirectional text correctly.