### PR TITLE
Wait to parse mailto until ComposerWidget

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -56,7 +56,7 @@ public class Mail.Application : Gtk.Application {
         // The only arguments we support are mailto: URLs passed in by the OS. See RFC 2368 for
         // details. We handle the most commonly used fields.
         foreach (var mailto_uri in argv[1:argv.length]) {
-            string to = null, bcc = null, cc = null, subject = null;
+            string to = null;
 
             try {
                 Soup.URI mailto = new Soup.URI (mailto_uri);
@@ -71,41 +71,13 @@ public class Mail.Application : Gtk.Application {
                 if (to == null || to == "") {
                     throw new OptionError.BAD_VALUE ("mailto: URL does not specify a recipent");
                 }
-                if (mailto.query != null) {
-                    var params = parse_mailto_query (mailto.query);
-                    if (params["bcc"] != null) {
-                        bcc = params["bcc"];
-                    }
-                    if (params["cc"] != null) {
-                        cc = params["cc"];
-                    }
-                    if (params["subject"] != null) {
-                        subject = params["subject"];
-                    }
-                }
-                new ComposerWindow.with_headers (main_window, to, bcc, cc, subject).show_all ();
+                new ComposerWindow (main_window, to, mailto.query).show_all ();
             } catch (OptionError e) {
                 warning ("Argument parsing error. %s", e.message);
             }
         }
 
         return 0;
-    }
-
-    private Gee.HashMap<string, string> parse_mailto_query (string query) throws OptionError {
-        var result = new Gee.HashMap<string, string> ();
-        var params = query.split ("&");
-
-        foreach (unowned string param in params) {
-            var terms = param.split ("=");
-            if (terms.length != 2) {
-                throw new OptionError.BAD_VALUE ("Invalid mailto URL");
-            }
-
-            result[terms[0]] = Soup.URI.decode (terms[1]);
-        }
-
-        return result;
     }
 
     public override void activate () {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -56,7 +56,7 @@ public class Mail.Application : Gtk.Application {
         // The only arguments we support are mailto: URLs passed in by the OS. See RFC 2368 for
         // details. We handle the most commonly used fields.
         foreach (var mailto_uri in argv[1:argv.length]) {
-            string to = null, cc = null, subject = null;
+            string to = null, bcc = null, cc = null, subject = null;
 
             try {
                 Soup.URI mailto = new Soup.URI (mailto_uri);
@@ -73,6 +73,9 @@ public class Mail.Application : Gtk.Application {
                 }
                 if (mailto.query != null) {
                     var params = parse_mailto_query (mailto.query);
+                    if (params["bcc"] != null) {
+                        bcc = params["bcc"];
+                    }
                     if (params["cc"] != null) {
                         cc = params["cc"];
                     }
@@ -80,7 +83,7 @@ public class Mail.Application : Gtk.Application {
                         subject = params["subject"];
                     }
                 }
-                new ComposerWindow.with_headers (main_window, to, cc, subject).show_all ();
+                new ComposerWindow.with_headers (main_window, to, bcc, cc, subject).show_all ();
             } catch (OptionError e) {
                 warning ("Argument parsing error. %s", e.message);
             }

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -46,7 +46,6 @@ public class Mail.ComposerWidget : Gtk.Grid {
     private Gtk.Entry cc_val;
     private Gtk.Entry bcc_val;
     private Gtk.Revealer cc_revealer;
-    private Gtk.ToggleButton bcc_button;
     private Gtk.ToggleButton cc_button;
     private Granite.Widgets.OverlayBar message_url_overlay;
     private Gtk.ComboBoxText from_combo;
@@ -123,7 +122,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
         cc_button = new Gtk.ToggleButton.with_label (_("Cc"));
 
-        bcc_button = new Gtk.ToggleButton.with_label (_("Bcc"));
+        var bcc_button = new Gtk.ToggleButton.with_label (_("Bcc"));
 
         var to_grid = new Gtk.Grid ();
         to_grid.add (to_val);

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -41,10 +41,11 @@ public class Mail.ComposerWidget : Gtk.Grid {
     private WebView web_view;
     private SimpleActionGroup actions;
     private Gtk.Entry to_val;
-    private Gtk.ToggleButton cc_button;
     private Gtk.Entry cc_val;
     private Gtk.Entry bcc_val;
     private Gtk.Revealer cc_revealer;
+    private Gtk.ToggleButton bcc_button;
+    private Gtk.ToggleButton cc_button;
     private Granite.Widgets.OverlayBar message_url_overlay;
     private Gtk.ComboBoxText from_combo;
     private Gtk.Entry subject_val;
@@ -78,12 +79,16 @@ public class Mail.ComposerWidget : Gtk.Grid {
         Object (has_subject_field: true);
     }
 
-    public ComposerWidget.with_headers (string? to, string? cc, string? subject) {
+    public ComposerWidget.with_headers (string? to, string? bcc, string? cc, string? subject) {
         Object (has_subject_field: true);
 
         // Set header fields, now that signal handlers are established
         if (to != null) {
             to_val.text = to;
+        }
+        if (bcc != null) {
+            bcc_button.clicked ();
+            bcc_val.text = bcc;
         }
         if (cc != null) {
             cc_button.clicked ();
@@ -128,7 +133,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
         cc_button = new Gtk.ToggleButton.with_label (_("Cc"));
 
-        var bcc_button = new Gtk.ToggleButton.with_label (_("Bcc"));
+        bcc_button = new Gtk.ToggleButton.with_label (_("Bcc"));
 
         var to_grid = new Gtk.Grid ();
         to_grid.add (to_val);

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -37,6 +37,8 @@ public class Mail.ComposerWidget : Gtk.Grid {
     public bool has_recipients { get; set; }
     public bool has_subject_field { get; construct; default = false; }
     public bool can_change_sender { get; construct; default = true; }
+    public string? to { get; construct; }
+    public string? mailto_query { get; construct; }
 
     private WebView web_view;
     private SimpleActionGroup actions;
@@ -79,24 +81,12 @@ public class Mail.ComposerWidget : Gtk.Grid {
         Object (has_subject_field: true);
     }
 
-    public ComposerWidget.with_headers (string? to, string? bcc, string? cc, string? subject) {
-        Object (has_subject_field: true);
-
-        // Set header fields, now that signal handlers are established
-        if (to != null) {
-            to_val.text = to;
-        }
-        if (bcc != null) {
-            bcc_button.clicked ();
-            bcc_val.text = bcc;
-        }
-        if (cc != null) {
-            cc_button.clicked ();
-            cc_val.text = cc;
-        }
-        if (subject != null) {
-            subject_val.text = subject;
-        }
+    public ComposerWidget.with_headers (string to, string? mailto_query) {
+        Object (
+            has_subject_field: true,
+            to: to,
+            mailto_query: mailto_query
+        );
     }
 
     construct {
@@ -363,6 +353,36 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
             to_grid_style_context.set_state (state);
         });
+
+        if (to != null) {
+            to_val.text = to;
+        }
+
+        if (mailto_query != null) {
+            var result = new Gee.HashMap<string, string> ();
+            var params = mailto_query.split ("&");
+
+            foreach (unowned string param in params) {
+                var terms = param.split ("=");
+                if (terms.length != 2) {
+                    critical ("Invalid mailto URL");
+                }
+
+                result[terms[0]] = Soup.URI.decode (terms[1]);
+            }
+
+            if (result["bcc"] != null) {
+                bcc_button.clicked ();
+                bcc_val.text = result["bcc"];
+            }
+            if (result["cc"] != null) {
+                cc_button.clicked ();
+                cc_val.text = result["cc"];
+            }
+            if (result["subject"] != null) {
+                subject_val.text = result["subject"];
+            }
+        }
     }
 
     private void on_insert_link_clicked () {

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -363,11 +363,11 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
             foreach (unowned string param in params) {
                 var terms = param.split ("=");
-                if (terms.length != 2) {
+                if (terms.length == 2) {
+                    result[terms[0]] = Soup.URI.decode (terms[1]);
+                } else {
                     critical ("Invalid mailto URL");
                 }
-
-                result[terms[0]] = Soup.URI.decode (terms[1]);
             }
 
             if (result["bcc"] != null) {

--- a/src/Composer/ComposerWindow.vala
+++ b/src/Composer/ComposerWindow.vala
@@ -20,6 +20,7 @@
 
 public class Mail.ComposerWindow : Gtk.ApplicationWindow {
     public string? to { get; construct; default = null; }
+    public string? bcc { get; construct; default = null; }
     public string? cc { get; construct; default = null; }
     public string? subject { get; construct; default = null; }
 
@@ -27,17 +28,18 @@ public class Mail.ComposerWindow : Gtk.ApplicationWindow {
         Object (transient_for: parent);
     }
 
-    public ComposerWindow.with_headers (Gtk.Window parent, string? to, string? cc, string? subject) {
+    public ComposerWindow.with_headers (Gtk.Window parent, string? to, string? bcc, string? cc, string? subject) {
         Object (
             transient_for: parent,
             to: to,
+            bcc: bcc,
             cc: cc,
             subject: subject
         );
     }
 
     construct {
-        var composer_widget = new ComposerWidget.with_headers (to, cc, subject);
+        var composer_widget = new ComposerWidget.with_headers (to, bcc, cc, subject);
         composer_widget.discarded.connect (() => {
             close ();
         });

--- a/src/Composer/ComposerWindow.vala
+++ b/src/Composer/ComposerWindow.vala
@@ -19,27 +19,19 @@
  */
 
 public class Mail.ComposerWindow : Gtk.ApplicationWindow {
-    public string? to { get; construct; default = null; }
-    public string? bcc { get; construct; default = null; }
-    public string? cc { get; construct; default = null; }
-    public string? subject { get; construct; default = null; }
+    public string? mailto_query { get; construct; }
+    public string? to { get; construct; }
 
-    public ComposerWindow (Gtk.Window parent) {
-        Object (transient_for: parent);
-    }
-
-    public ComposerWindow.with_headers (Gtk.Window parent, string? to, string? bcc, string? cc, string? subject) {
+    public ComposerWindow (Gtk.Window parent, string? to = null, string? mailto_query = null) {
         Object (
             transient_for: parent,
-            to: to,
-            bcc: bcc,
-            cc: cc,
-            subject: subject
+            mailto_query: mailto_query,
+            to: to
         );
     }
 
     construct {
-        var composer_widget = new ComposerWidget.with_headers (to, bcc, cc, subject);
+        var composer_widget = new ComposerWidget.with_headers (to, mailto_query);
         composer_widget.discarded.connect (() => {
             close ();
         });


### PR DESCRIPTION
Doing it this way we simplify the number of arguments we're passing by quite a bit and we keep ComposerWidget to be a more strict GObject style

Also add BCC support