### PR TITLE
#396: work around bug with action groups in GTK, to avoid a crash

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -75,7 +75,10 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             if (row == null) {
                 conversation_selected (null);
             } else {
-                weak GLib.ActionMap win_action_map = (GLib.ActionMap) get_action_group (MainWindow.ACTION_GROUP_PREFIX);
+                // We call get_action_group() on the parent window, instead of on `this` directly, due to a
+                // bug with Gtk.Widget.get_action_group(). See https://gitlab.gnome.org/GNOME/gtk/issues/1396
+                var window = (Gtk.ApplicationWindow) get_toplevel ();
+                weak GLib.ActionMap win_action_map = (GLib.ActionMap) window.get_action_group (MainWindow.ACTION_GROUP_PREFIX);
                 ((SimpleAction) win_action_map.lookup_action (MainWindow.ACTION_MARK_READ)).set_enabled (((ConversationItemModel) row).unread);
                 ((SimpleAction) win_action_map.lookup_action (MainWindow.ACTION_MARK_UNREAD)).set_enabled (!((ConversationItemModel) row).unread);
                 conversation_selected (((ConversationItemModel) row).node);


### PR DESCRIPTION
I'll try to fix the underlying bug in GTK this weekend, but it could be a while before a fixed upstream library is available.

Fixes #396 