### PR TITLE
Allow empty mailto: URL, so compose menu item in Dock will work (#400)

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -68,9 +68,6 @@ public class Mail.Application : Gtk.Application {
                 }
 
                 to = Soup.URI.decode (mailto.path);
-                if (to == null || to == "") {
-                    throw new OptionError.BAD_VALUE ("mailto: URL does not specify a recipent");
-                }
                 new ComposerWindow (main_window, to, mailto.query).show_all ();
             } catch (OptionError e) {
                 warning ("Argument parsing error. %s", e.message);


### PR DESCRIPTION
This also allows weirdness like `mailto:?cc=foo@example.com`, but that seems fine if someone really wants to do that.