### PR TITLE
Use correct sidebar icons

### DIFF
--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -62,9 +62,8 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
         }
 
         
-        // Camel.FolderInfo.Flags does not return expected values for multiple types of mail folders
-        // after being processed by bitwise AND the Camel.FOLDER_TYPE_MASK. Original comparisons are
-        // preserved if libcamel is ever updated to address this issue.
+        // (Camel.FolderInfo.Flags & Camel.FOLDER_TYPE_MASK) does not return expected values for multiple types of folders.
+        // Original comparisons are preserved if/when this bug is fixed in libcamel.
         var masked_flag = folderinfo.flags & Camel.FOLDER_TYPE_MASK;
         var lowercase_full_name = full_name.down ();
 

--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -67,7 +67,7 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
         // preserved if libcamel is ever updated to address this issue.
         var masked_flag = folderinfo.flags & Camel.FOLDER_TYPE_MASK;
         var lowercase_full_name = full_name.down ();
-        
+
         if (masked_flag == Camel.FolderInfoFlags.TYPE_INBOX ||
         lowercase_full_name.contains ("inbox")) {
             icon = new ThemedIcon ("mail-inbox");
@@ -82,7 +82,8 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
             can_modify = false;
             badge = null;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_JUNK ||
-        lowercase_full_name.contains ("junk")) {
+        lowercase_full_name.contains ("junk") ||
+        lowercase_full_name.contains ("spam")) {
             icon = new ThemedIcon ("edit-flag");
             can_modify = false;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_SENT ||

--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -60,7 +60,6 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
         if (folderinfo.unread > 0) {
             badge = "%d".printf (folderinfo.unread);
         }
-
         
         // (Camel.FolderInfo.Flags & Camel.FOLDER_TYPE_MASK) does not return expected values for multiple types of folders.
         // Original comparisons are preserved if/when this bug is fixed in libcamel.
@@ -68,34 +67,34 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
         var lowercase_full_name = full_name.down ();
 
         if (masked_flag == Camel.FolderInfoFlags.TYPE_INBOX ||
-        lowercase_full_name.contains ("inbox")) {
+                lowercase_full_name.contains ("inbox")) {
             icon = new ThemedIcon ("mail-inbox");
             can_modify = false; 
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_OUTBOX ||
-        lowercase_full_name.contains ("outbox")) {
+                lowercase_full_name.contains ("outbox")) {
             icon = new ThemedIcon ("mail-outbox");
             can_modify = false;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_TRASH ||
-        lowercase_full_name.contains ("trash")) {
+                lowercase_full_name.contains ("trash")) {
             icon = new ThemedIcon (folderinfo.total == 0 ? "user-trash" : "user-trash-full");
             can_modify = false;
             badge = null;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_JUNK ||
-        lowercase_full_name.contains ("junk") ||
+                lowercase_full_name.contains ("junk") ||
         lowercase_full_name.contains ("spam")) {
             icon = new ThemedIcon ("edit-flag");
             can_modify = false;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_SENT ||
-        lowercase_full_name.contains ("sent")) {
+                lowercase_full_name.contains ("sent")) {
             icon = new ThemedIcon ("mail-sent");
             can_modify = false;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_ARCHIVE ||
-        lowercase_full_name.contains ("archive")) {
+                lowercase_full_name.contains ("archive")) {
             icon = new ThemedIcon ("mail-archive");
             can_modify = false;
             badge = null;
         } else if (masked_flag == Camel.FolderInfoFlags.TYPE_DRAFTS ||
-        lowercase_full_name.contains ("draft")) {
+                lowercase_full_name.contains ("draft")) {
             icon = new ThemedIcon ("folder-documents");
             can_modify = false;
         } else {

--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -61,41 +61,46 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
             badge = "%d".printf (folderinfo.unread);
         }
 
-        switch (folderinfo.flags & Camel.FOLDER_TYPE_MASK) {
-            case Camel.FolderInfoFlags.TYPE_INBOX:
-                icon = new ThemedIcon ("mail-inbox");
-                can_modify = false;
-                break;
-            case Camel.FolderInfoFlags.TYPE_OUTBOX:
-                icon = new ThemedIcon ("mail-outbox");
-                can_modify = false;
-                break;
-            case Camel.FolderInfoFlags.TYPE_TRASH:
-                icon = new ThemedIcon (folderinfo.total == 0 ? "user-trash" : "user-trash-full");
-                can_modify = false;
-                badge = null;
-                break;
-            case Camel.FolderInfoFlags.TYPE_JUNK:
-                icon = new ThemedIcon ("edit-flag");
-                can_modify = false;
-                break;
-            case Camel.FolderInfoFlags.TYPE_SENT:
-                icon = new ThemedIcon ("mail-sent");
-                can_modify = false;
-                break;
-            case Camel.FolderInfoFlags.TYPE_ARCHIVE:
-                icon = new ThemedIcon ("mail-archive");
-                can_modify = false;
-                badge = null;
-                break;
-            case Camel.FolderInfoFlags.TYPE_DRAFTS:
-                icon = new ThemedIcon ("folder-documents");
-                can_modify = false;
-                break;
-            default:
-                icon = new ThemedIcon ("folder");
-                can_modify = true;
-                break;
+        
+        // Camel.FolderInfo.Flags does not return expected values for multiple types of mail folders
+        // after being processed by bitwise AND the Camel.FOLDER_TYPE_MASK. Original comparisons are
+        // preserved if libcamel is ever updated to address this issue.
+        var masked_flag = folderinfo.flags & Camel.FOLDER_TYPE_MASK;
+        var lowercase_full_name = full_name.down ();
+        
+        if (masked_flag == Camel.FolderInfoFlags.TYPE_INBOX ||
+        lowercase_full_name.contains ("inbox")) {
+            icon = new ThemedIcon ("mail-inbox");
+            can_modify = false; 
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_OUTBOX ||
+        lowercase_full_name.contains ("outbox")) {
+            icon = new ThemedIcon ("mail-outbox");
+            can_modify = false;
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_TRASH ||
+        lowercase_full_name.contains ("trash")) {
+            icon = new ThemedIcon (folderinfo.total == 0 ? "user-trash" : "user-trash-full");
+            can_modify = false;
+            badge = null;
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_JUNK ||
+        lowercase_full_name.contains ("junk")) {
+            icon = new ThemedIcon ("edit-flag");
+            can_modify = false;
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_SENT ||
+        lowercase_full_name.contains ("sent")) {
+            icon = new ThemedIcon ("mail-sent");
+            can_modify = false;
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_ARCHIVE ||
+        lowercase_full_name.contains ("archive")) {
+            icon = new ThemedIcon ("mail-archive");
+            can_modify = false;
+            badge = null;
+        } else if (masked_flag == Camel.FolderInfoFlags.TYPE_DRAFTS ||
+        lowercase_full_name.contains ("draft")) {
+            icon = new ThemedIcon ("folder-documents");
+            can_modify = false;
+        } else {
+            icon = new ThemedIcon ("folder");
+            can_modify = true;
         }
     }
 }


### PR DESCRIPTION
This should fix #262, although a better solution could be available eventually.

This solution is very inelegant, to the point I feel I need to explain why I did it this way. Icons are handled and assigned by FolderSourceItem.update_infos(). update_infos() follows the [advice of the libcamel documentation](https://developer.gnome.org/camel/stable/camel-camel-enums.html#CamelFolderInfoFlags) and compares the binary AND result of both folderinfo.flags and Camel.FOLDER_TYPE_MASK to the enum Camel.FolderInfoFlags.TYPE_X values. The problem is this value isn't returning the expected number for some of the values, this results some icons using the "folder-documents" icon.

I checked to see how evolution handles it and Evolution just checks the names for 5 of the values, using a boolean for 2 of them to track if its true or not, and the 3 others they supply a modified value (if i'm understanding my boolean math correctly). Evolution then sends all other results to a different function with a similar switch statement to what Mail was already doing.

The relevant evolution code is in [em-folder-tree-model.c](https://gitlab.gnome.org/GNOME/evolution/blob/2fa97de820634ac002784165bb122bc32e651235/src/mail/em-folder-tree-model.c#L691) and [em-folder-utils.c](https://gitlab.gnome.org/GNOME/evolution/blob/2fa97de820634ac002784165bb122bc32e651235/src/mail/em-folder-utils.c#L596). Hopefully I didn't miss anything in Evolution. I suspect that something is up in libcamel, but I did keep the original comparisons as well. This would provide for a slightly more robust behavior if libcamel ever gets fixed, and a basic "fallback" behavior if its not.

![image](https://user-images.githubusercontent.com/30452393/63068224-f50c9780-bed7-11e9-820e-cdb8b714f66b.png)

edit: fixed a typo.