### PR TITLE
Support body parameter for mailto URLs

### DIFF
--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -360,7 +360,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
             foreach (unowned string param in params) {
                 var terms = param.split ("=");
                 if (terms.length == 2) {
-                    result[terms[0]] = Soup.URI.decode (terms[1]);
+                    result[terms[0].down ()] = Soup.URI.decode (terms[1]);
                 } else {
                     critical ("Invalid mailto URL");
                 }
@@ -370,12 +370,24 @@ public class Mail.ComposerWidget : Gtk.Grid {
                 bcc_button.clicked ();
                 bcc_val.text = result["bcc"];
             }
+
             if (result["cc"] != null) {
                 cc_button.clicked ();
                 cc_val.text = result["cc"];
             }
+
             if (result["subject"] != null) {
                 subject_val.text = result["subject"];
+            }
+
+            if (result["body"] != null) {
+                var flags =
+                    Camel.MimeFilterToHTMLFlags.CONVERT_ADDRESSES |
+                    Camel.MimeFilterToHTMLFlags.CONVERT_NL |
+                    Camel.MimeFilterToHTMLFlags.CONVERT_SPACES |
+                    Camel.MimeFilterToHTMLFlags.CONVERT_URLS;
+
+                web_view.set_body_content (Camel.text_to_html (result["body"], flags, 0));
             }
         }
     }


### PR DESCRIPTION
Fixes #394 

Use `Camel.text_to_html` to convert a `body` query parameter on `mailto:` URLs. We set up the flags to automatically convert URLs and email addresses into hyperlinks and line breaks and space characters into the relevant HTML entities.

While I was here, I converted the query parameter key to lowercase so we're case insensitive about the query parameters.