### PR TITLE
ComposerWidget: Use css_name to style to entry

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -6,32 +6,33 @@
     box-shadow: 0 -1px 0 @menu_separator;
 }
 
-.entry button,
-.entry entry {
+entry button,
+entry entry {
 	border: none;
 	box-shadow: none;
 	background: none;
 	padding: 0;
 }
 
-.entry button label {
+entry button label {
     opacity: 0.6;
+    padding: 0 3px;
 }
 
-.entry button:hover label {
+entry button:hover label {
     opacity: 1;
 }
 
-.entry button:focus {
+entry button:focus {
     background-color: alpha (@text_color, 0.15);
 }
 
-.entry button:checked label {
-    color: @colorAccent;
+entry button:checked label {
+    color: @accent_color;
     opacity: 1;
 }
 
-.entry button:disabled label {
+entry button:disabled label {
     opacity: 0.5;
 }
 

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -120,13 +120,10 @@ public class Mail.ComposerWidget : Gtk.Grid {
 
         var bcc_button = new Gtk.ToggleButton.with_label (_("Bcc"));
 
-        var to_grid = new Gtk.Grid ();
+        var to_grid = new EntryGrid ();
         to_grid.add (to_val);
         to_grid.add (cc_button);
         to_grid.add (bcc_button);
-
-        var to_grid_style_context = to_grid.get_style_context ();
-        to_grid_style_context.add_class (Gtk.STYLE_CLASS_ENTRY);
 
         var cc_label = new Gtk.Label (_("Cc:"));
         cc_label.xalign = 1;
@@ -339,6 +336,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
         });
 
         to_val.get_style_context ().changed.connect (() => {
+            unowned Gtk.StyleContext to_grid_style_context = to_grid.get_style_context ();
             var state = to_grid_style_context.get_state ();
             if (to_val.has_focus) {
                 state |= Gtk.StateFlags.FOCUSED;
@@ -616,5 +614,11 @@ public class Mail.ComposerWidget : Gtk.Grid {
         }
 
         from_combo.active = 0;
+    }
+
+    private class EntryGrid : Gtk.Grid {
+        static construct {
+            set_css_name (Gtk.STYLE_CLASS_ENTRY);
+        }
     }
 }


### PR DESCRIPTION
So we don't have to add a `.entry` class to the stylesheet