### PR TITLE
Ensure selection state is unset on recycled widgets

### DIFF
--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -205,7 +205,10 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         VirtualizingListBoxRow new_widget = factory_func (item, old_widget);
         if (model.get_item_selected (item)) {
             new_widget.set_state_flags (Gtk.StateFlags.SELECTED, false);
+        } else {
+            new_widget.unset_state_flags (Gtk.StateFlags.SELECTED);
         }
+
         new_widget.model_item = item;
         new_widget.show ();
 


### PR DESCRIPTION
We were seeing some buggy selection state behaviour in the conversation list box when the list refreshed or was updated. This helps to resolve some/most of these issues.