### PR TITLE
Add window title

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -87,6 +87,8 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     construct {
+        title = _("Mail");
+
         add_action_entries (ACTION_ENTRIES, this);
         get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -66,7 +66,8 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             application: application,
             height_request: 600,
             icon_name: "io.elementary.mail",
-            width_request: 800
+            width_request: 800,
+            title: _("Mail")
         );
     }
 
@@ -87,8 +88,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     construct {
-        title = _("Mail");
-
         add_action_entries (ACTION_ENTRIES, this);
         get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
 


### PR DESCRIPTION
At the moment, the main window doesn't have a title. It is not a big deal since the title is not displayed anywhere in the UI.
However, once https://github.com/elementary/gala/issues/798 gets fixed, Gala will display "io.elementary.mail" as window title.