### PR TITLE
Grouped Folders: Made Type Configurable

### DIFF
--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -21,9 +21,10 @@
  */
 
 public class Mail.FoldersListView : Gtk.ScrolledWindow {
-    public signal void folder_selected (Backend.Account[] accounts, string folder_name);
+    public signal void folder_selected (Gee.Map<Backend.Account, string?> folder_full_name_per_account);
 
     private Granite.Widgets.SourceList source_list;
+    private Mail.SessionSourceItem session_source_item;
     private static GLib.Settings settings;
 
     static construct {
@@ -37,7 +38,7 @@ public class Mail.FoldersListView : Gtk.ScrolledWindow {
         add (source_list);
         var session = Mail.Backend.Session.get_default ();
 
-        var session_source_item = new Mail.SessionSourceItem (session);
+        session_source_item = new Mail.SessionSourceItem (session);
         source_list.root.add (session_source_item);
 
         session.get_accounts ().foreach ((account) => {
@@ -53,27 +54,19 @@ public class Mail.FoldersListView : Gtk.ScrolledWindow {
 
             if (item is FolderSourceItem) {
                 unowned FolderSourceItem folder_item = (FolderSourceItem) item;
-                folder_selected ({ folder_item.account }, folder_item.full_name);
+                var folder_name_per_account = new Gee.HashMap<Mail.Backend.Account, string?> ();
+                folder_name_per_account.set (folder_item.account, folder_item.full_name);
+                folder_selected (folder_name_per_account.read_only_view);
 
                 settings.set ("selected-folder", "(ss)", folder_item.account.service.uid, folder_item.full_name);
 
             } else if (item is GroupedFolderSourceItem) {
                 unowned GroupedFolderSourceItem grouped_folder_item = (GroupedFolderSourceItem) item;
-                folder_selected (grouped_folder_item.get_accounts (), grouped_folder_item.full_name);
+                folder_selected (grouped_folder_item.get_folder_full_name_per_account ());
 
-                settings.set ("selected-folder", "(ss)", "GROUPED", grouped_folder_item.full_name);
+                settings.set ("selected-folder", "(ss)", "GROUPED", grouped_folder_item.name);
             }
         });
-
-        string selected_folder_uid, selected_folder_name;
-        settings.get ("selected-folder", "(ss)", out selected_folder_uid, out selected_folder_name);
-
-        if (selected_folder_uid == "GROUPED") {
-            GLib.Idle.add (() => {
-                select_saved_folder (session_source_item, selected_folder_name);
-                return GLib.Source.REMOVE;
-            });
-        }
     }
 
     private void add_account (Mail.Backend.Account account) {
@@ -81,10 +74,15 @@ public class Mail.FoldersListView : Gtk.ScrolledWindow {
         source_list.root.add (account_item);
         account_item.load.begin ((obj, res) => {
             account_item.load.end (res);
+
             string selected_folder_uid, selected_folder_name;
             settings.get ("selected-folder", "(ss)", out selected_folder_uid, out selected_folder_name);
+
             if (account.service.uid == selected_folder_uid) {
                 select_saved_folder (account_item, selected_folder_name);
+
+            } else if (selected_folder_uid == "GROUPED") {
+                select_saved_folder (session_source_item, selected_folder_name);
             }
         });
     }
@@ -99,19 +97,22 @@ public class Mail.FoldersListView : Gtk.ScrolledWindow {
                 unowned FolderSourceItem folder_item = (FolderSourceItem) child;
                 if (folder_item.full_name == selected_folder_name) {
                     source_list.selected = child;
-                    folder_selected ({ folder_item.account }, selected_folder_name);
+
+                    var folder_name_per_account = new Gee.HashMap<Mail.Backend.Account, string?> ();
+                    folder_name_per_account.set (folder_item.account, folder_item.full_name);
+                    folder_selected (folder_name_per_account.read_only_view);
                     return true;
                 }
 
             } else if (child is GroupedFolderSourceItem) {
                 unowned GroupedFolderSourceItem grouped_folder_item = (GroupedFolderSourceItem) child;
-                if (grouped_folder_item.full_name == selected_folder_name) {
+                if (grouped_folder_item.name == selected_folder_name) {
                     source_list.selected = child;
+                    folder_selected (grouped_folder_item.get_folder_full_name_per_account ());
                     return true;
                 }
             }
         }
-
         return false;
     }
 }

--- a/src/FoldersView/SessionSourceItem.vala
+++ b/src/FoldersView/SessionSourceItem.vala
@@ -30,7 +30,7 @@
         expanded = true;
         collapsible = false;
 
-        add (new GroupedFolderSourceItem (session));
+        add (new GroupedFolderSourceItem (session, Camel.FolderInfoFlags.TYPE_INBOX));
 
         session.account_added.connect (added_account);
         session.account_removed.connect (removed_account);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -189,8 +189,8 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         destroy.connect (() => destroy ());
 
-        folders_list_view.folder_selected.connect ((accounts, folder_name) => {
-            conversation_list_box.load_folder.begin (accounts, folder_name);
+        folders_list_view.folder_selected.connect ((folder_full_name_per_account) => {
+            conversation_list_box.load_folder.begin (folder_full_name_per_account);
         });
 
         conversation_list_box.conversation_selected.connect ((node) => {


### PR DESCRIPTION
This PR adds the infrastructure to support different kind of grouped folders. It builds upon #571 and uses the `Camel.FolderInfoFlag.TYPE_*` enum to decide which grouped folder should be rendered.

The only pieces missing are figuring out the folder specific `full_name` attribute per account. This has already been solved in the first attempt of the grouped inbox - but the code did not make its way into master because we dropped it in order to make review easier:

https://github.com/elementary/mail/blob/a75adfd100fe9dcef98d700b7230b466f91fd2e7/src/FoldersView/GroupedFolderSourceItem.vala