### PR TITLE
Grouped Folders: Sent

### DIFF
--- a/src/FoldersView/GroupedFolderSourceItem.vala
+++ b/src/FoldersView/GroupedFolderSourceItem.vala
@@ -166,7 +166,10 @@ public class Mail.GroupedFolderSourceItem : Granite.Widgets.SourceList.Item {
         return null;
     }
 
-    private string strip_folder_full_name (string service_uid, string folder_uri) {
-        return folder_uri.replace ("folder://%s/".printf (service_uid), "");
+    private string? strip_folder_full_name (string service_uid, string? folder_uri) {
+        if (folder_uri != null) {
+            return folder_uri.replace ("folder://%s/".printf (service_uid), "");
+        }
+        return null;
     }
 }

--- a/src/FoldersView/GroupedFolderSourceItem.vala
+++ b/src/FoldersView/GroupedFolderSourceItem.vala
@@ -42,6 +42,10 @@ public class Mail.GroupedFolderSourceItem : Granite.Widgets.SourceList.Item {
                 name = _("Archive");
                 icon = new ThemedIcon ("mail-archive");
                 break;
+            case Camel.FolderInfoFlags.TYPE_SENT:
+                name = _("Sent");
+                icon = new ThemedIcon ("mail-sent");
+                break;
             default:
                 name = "%i".printf (folder_type & Camel.FOLDER_TYPE_MASK);
                 icon = new ThemedIcon ("folder");
@@ -145,6 +149,18 @@ public class Mail.GroupedFolderSourceItem : Granite.Widgets.SourceList.Item {
 
             if (Camel.FolderInfoFlags.TYPE_ARCHIVE == (folder_type & Camel.FOLDER_TYPE_MASK)) {
                 return strip_folder_full_name (account.service.uid, mail_account_extension.dup_archive_folder ());
+            }
+
+            var identity_uid = mail_account_extension.dup_identity_uid ();
+            var identity_source = session.ref_source (identity_uid);
+
+            switch (folder_type & Camel.FOLDER_TYPE_MASK) {
+                case Camel.FolderInfoFlags.TYPE_SENT:
+                    if (identity_source.has_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION)) {
+                        var mail_submission_extension = (E.SourceMailSubmission) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION);
+                        return strip_folder_full_name (account.service.uid, mail_submission_extension.dup_sent_folder ());
+                    }
+                    break;
             }
         }
         return null;

--- a/src/FoldersView/SessionSourceItem.vala
+++ b/src/FoldersView/SessionSourceItem.vala
@@ -32,6 +32,7 @@
 
         add (new GroupedFolderSourceItem (session, Camel.FolderInfoFlags.TYPE_INBOX));
         add (new GroupedFolderSourceItem (session, Camel.FolderInfoFlags.TYPE_ARCHIVE));
+        add (new GroupedFolderSourceItem (session, Camel.FolderInfoFlags.TYPE_SENT));
 
         session.account_added.connect (added_account);
         session.account_removed.connect (removed_account);


### PR DESCRIPTION
This PR re-adds the unified Sent folder. However, we do have two issues to solve with the current implementation:

- [x] Interestingly the items of the Sent folder do not seem to be loaded on application startup - this differs from INBOX and Archive
- [x] I still sometimes get a Segmentation fault on application start:

```
(gdb) backtrace
#0  0x00007f558862c434 in camel_message_info_get_date_received () at /lib/x86_64-linux-gnu/libcamel-1.2.so.62
#1  0x0000562d66f7e2ef in mail_conversation_item_model_get_newest_timestamp (node=0x7ffc405cc4c0, highest=1537724696)
    at ../src/ConversationList/ConversationItemModel.vala:168
#2  0x0000562d66f7e4a7 in mail_conversation_item_model_get_newest_timestamp (node=0x7ffc405cc620, highest=1537724696)
    at ../src/ConversationList/ConversationItemModel.vala:173
#3  0x0000562d66f7e4a7 in mail_conversation_item_model_get_newest_timestamp (node=0x7ffc405cc780, highest=1537724696)
    at ../src/ConversationList/ConversationItemModel.vala:173
#4  0x0000562d66f7e4a7 in mail_conversation_item_model_get_newest_timestamp (node=0x7ffc405cc8e0, highest=1537724696)
    at ../src/ConversationList/ConversationItemModel.vala:173
#5  0x0000562d66f7e4a7 in mail_conversation_item_model_get_newest_timestamp (node=0x7ffc405cc960, highest=-1)
    at ../src/ConversationList/ConversationItemModel.vala:173
#6  0x0000562d66f7f0d0 in mail_conversation_item_model_get_timestamp (self=0x562d68c03c10)
    at ../src/ConversationList/ConversationItemModel.vala:142
#7  0x0000562d66f82902 in mail_conversation_list_box_thread_sort_function (item1=0x562d68c03c10, item2=0x562d68f90550)
    at ../src/ConversationList/ConversationListBox.vala:253
#8  0x0000562d66f84be0 in _mail_conversation_list_box_thread_sort_function_gcompare_data_func
    (a=0x562d68c03c10, b=0x562d68f90550, self=0x0) at ConversationListBox.c:3163
#9  0x00007f55894764fc in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#10 0x00007f55894769df in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#11 0x00007f55894778b4 in g_sequence_insert_sorted_iter () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#12 0x00007f5589477998 in g_sequence_insert_sorted () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#13 0x0000562d66f87b5f in mail_conversation_list_store_add (self=0x562d678989e0, data=0x562d68f90550)
    at ../src/ConversationList/ConversationListStore.vala:81
#14 0x0000562d66f82835 in mail_conversation_list_box_add_conversation_item
    (self=0x562d678a4290, child=0x7ffc405ccdb0, service_uid=0x562d67c15950 "b22759c8bc5255fee4879df77529bb96dce6215b")
    at ../src/ConversationList/ConversationListBox.vala:249
#15 0x0000562d66f81d2c in mail_conversation_list_box_folder_changed
    (self=0x562d678a4290, change_info=0x562d68f8fef0, service_uid=0x562d67c15950 "b22759c8bc5255fee4879df77529bb96dce6215b", cancellable=0x562d67e2f660) at ../src/ConversationList/ConversationListBox.vala:205
#16 0x0000562d66f7fe33 in _____________lambda22_ (_data12_=0x562d676e3f00, change_info=0x562d68f8fef0)
    at ../src/ConversationList/ConversationListBox.vala:146
#17 0x0000562d66f7fe60 in ______________lambda22__camel_folder_changed
    (_sender=0x562d67832b30, changes=0x562d68f8fef0, self=0x562d676e3f00) at ../src/ConversationList/ConversationListBox.vala:146
#18 0x00007f55893be802 in g_closure_invoke () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#19 0x00007f55893d2814 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#20 0x00007f55893ddbbe in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#21 0x00007f55893de0f3 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#22 0x00007f558861390d in  () at /lib/x86_64-linux-gnu/libcamel-1.2.so.62
#23 0x00007f558945c04e in g_main_context_dispatch () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#24 0x00007f558945c400 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#25 0x00007f558945c4a3 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#26 0x00007f5588893fe5 in g_application_run () at /lib/x86_64-linux-gnu/libgio-2.0.so.0
#27 0x0000562d66f588e4 in _vala_main (args=0x7ffc405cd5e8, args_length1=1) at ../src/Application.vala:123
#28 0x0000562d66f5892b in main (argc=1, argv=0x7ffc405cd5e8) at ../src/Application.vala:121
```