### PR TITLE
Add Drafts icons

### DIFF
--- a/data/icons/mail-drafts/16.svg
+++ b/data/icons/mail-drafts/16.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg8498">
+  <defs
+     id="defs8500">
+    <linearGradient
+       x1="32.892288"
+       y1="8.0590115"
+       x2="36.358372"
+       y2="5.4565363"
+       id="linearGradient3078"
+       xlink:href="#linearGradient8589"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34972769,0,0,0.35610773,-1.348519,0.29391874)" />
+    <linearGradient
+       id="linearGradient8589">
+      <stop
+         id="stop8591"
+         style="stop-color:#fefefe;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8593"
+         style="stop-color:#cbcbcb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="102"
+       cy="112.3047"
+       r="139.55859"
+       id="radialGradient3085"
+       xlink:href="#XMLID_8_"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12846887,0,0,-0.14049355,-1.243349,17.721389)" />
+    <radialGradient
+       cx="102"
+       cy="112.3047"
+       r="139.55859"
+       id="XMLID_8_"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop41"
+         style="stop-color:#b7b8b9;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop47"
+         style="stop-color:#ececec;stop-opacity:1"
+         offset="0.18851049" />
+      <stop
+         id="stop49"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset="0.25718147" />
+      <stop
+         id="stop51"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.30111277" />
+      <stop
+         id="stop53"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset="0.53130001" />
+      <stop
+         id="stop55"
+         style="stop-color:#ebecec;stop-opacity:0"
+         offset="0.84490001" />
+      <stop
+         id="stop57"
+         style="stop-color:#e1e2e3;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient7360"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128981,-0.68547126)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.2052388"
+       x2="23.99999"
+       y2="41.589603"
+       id="linearGradient7363"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.162161,-0.43242126)" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02929282" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97230476" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient8496"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428709,0.23260874)" />
+  </defs>
+  <metadata
+     id="metadata8503">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="m 3.000001,1.0000087 c 2.29151,0 6.35344,8.9e-4 6.35344,8.9e-4 l 3.64655,3.2679703 10e-6,10.73114 c 0,0 -6.66667,0 -10,0 0,-4.66667 0,-9.33333 0,-14.0000003 z"
+       id="path4160"
+       style="fill:url(#linearGradient8496);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 12.500001,14.500009 -9,0 0,-13 5.49894,0 3.50106,3.33947 z"
+       id="rect6741-1"
+       style="fill:none;stroke:url(#linearGradient7363);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    <path
+       d="m 2.499961,0.49997874 6.76766,5.1e-4 c 0.61416,0 4.23241,2.73141026 4.23241,3.88354026 l 10e-6,11.11601 c 0,0 -7.33339,0 -11.00008,0 0,-5.00002 0,-15.00006026 0,-15.00006026 z"
+       id="path4160-8"
+       style="fill:none;stroke:url(#linearGradient7360);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    <path
+       d="m 9.326881,1.0123287 3.65217,3.1875403 c 0,11.15219 -12.05670008,-3.1875403 -3.65217,-3.1875403 z"
+       id="path4191"
+       style="fill:url(#radialGradient3085);fill-opacity:1" />
+    <path
+       d="m 6.172041,1.0126387 c 1.11697,0 0.82796,4.9873703 0.82796,4.9873703 0,0 6.1005,-0.69597 6.1005,0.8853 0,-0.38528 -0.0846,-2.03569 -0.1616,-2.15591 -0.55326,-0.86374 -3.68844,-3.37544 -4.55138,-3.62946 -1.21584,-0.12804026 -2.21548,-0.0873 -2.21548,-0.0873 z"
+       id="path4474-4-2"
+       style="opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+    <path
+       d="m 7.000001,0.98754874 c 1.11697,0 1,4.01246026 1,4.01246026 0,0 5.01089,-0.58127 5.01089,1 0,-0.38528 0.0301,-1.8063 -0.0469,-1.92652 -0.55326,-0.86374 -2.94292,-2.80197 -3.80586,-3.0559903 -0.69408,-0.058 -2.15813,-0.0299 -2.15813,-0.0299 z"
+       id="path4474-4"
+       style="opacity:0.12000002;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+    <path
+       d="m 8.000001,0.98754874 c 1.11697,0 1,3.01246026 1,3.01246026 0,0 4.01089,-0.58127 4.01089,1 0,-0.38528 0.0301,-0.8063 -0.0469,-0.92652 -0.55326,-0.86374 -2.94292,-2.80197 -3.80586,-3.0559903 -0.17779,-0.005 -0.98055,-0.02 -1.15813,-0.0299 z"
+       id="path4474"
+       style="fill:url(#linearGradient3078);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+  </g>
+</svg>

--- a/data/icons/mail-drafts/48.svg
+++ b/data/icons/mail-drafts/48.svg
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient6129">
+      <stop
+         id="stop6121"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6123"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.54890001" />
+      <stop
+         id="stop6125"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop6127"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4053">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4049" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4051" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       x1="32.892288"
+       y1="8.0590115"
+       x2="36.358372"
+       y2="5.4565363"
+       id="linearGradient3078"
+       xlink:href="#linearGradient8589"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1125274,0,0,1.0455455,-4.6975076,-1.0365234)" />
+    <linearGradient
+       id="linearGradient8589">
+      <stop
+         id="stop8591"
+         style="stop-color:#fefefe;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8593"
+         style="stop-color:#cbcbcb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient4053"
+       id="radialGradient4055"
+       cx="35.223251"
+       cy="4.241622"
+       fx="35.223251"
+       fy="4.241622"
+       r="8.9522768"
+       gradientTransform="matrix(-0.93534075,0.81974018,-1.0404113,-0.93314779,73.505745,-21.418824)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient6129"
+       id="linearGradient5658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       x1="37.40815"
+       y1="5.1416016"
+       x2="33.666328"
+       y2="17.309727" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 4.23659,0 13.250512,8.102e-4 21.20353,0.00155 1.274005,0 12.796436,7.9271219 12.796438,9.7175115 L 41,44 H 7 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none" />
+  <path
+     id="path3920"
+     style="font-variation-settings:normal;opacity:0.28871963;vector-effect:none;fill:url(#radialGradient4055);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M 20.271484 1.0019531 A 15.836925 8.2492475 35.119375 0 0 29.681641 13.787109 A 15.836925 8.2492475 35.119375 0 0 41 18.0625 L 41 10.71875 C 40.999998 8.92836 29.47713 1.0019531 28.203125 1.0019531 C 25.228069 1.0016764 23.237843 1.0022035 20.271484 1.0019531 z " />
+  <path
+     d="m 6.4999605,0.4999623 c 4.3722215,0 13.9271505,8.8561e-4 22.1257215,0.001691 1.902806,0 12.874328,7.8557059 12.874328,10.0653907 l 2.9e-5,33.932994 H 6.4999605 V 0.5001457 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 40.5,43.5 H 7.5 V 1.5000002 h 21.199326 c 1.249357,0 11.800674,7.339339 11.800674,9.2436328 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     id="path4474-6-1"
+     style="font-variation-settings:normal;display:inline;opacity:0.07;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M 25.091797 1.0019531 L 25.041016 3 C 25.514559 3 25.798875 3.2197277 26.164062 3.8710938 C 26.529251 4.5224597 26.81118 5.5371521 26.976562 6.578125 C 27.307327 8.6600708 27.224609 10.802734 27.224609 10.802734 A 0.99995264 0.99995264 0 0 0 28.355469 11.833984 C 28.355469 11.833984 31.485589 11.422106 34.554688 11.570312 C 36.089236 11.644417 37.60287 11.873092 38.607422 12.287109 C 39.109698 12.494118 39.471871 12.743316 39.681641 12.982422 C 39.891411 13.221527 39.982422 13.429914 39.982422 13.78125 A 1 1 0 0 0 41 14.777344 L 41 10.71875 C 40.999998 9.0333856 30.791829 1.913894 28.53125 1.0839844 C 27.766511 1.0662473 25.527247 1.0243584 25.091797 1.0019531 z " />
+  <path
+     d="m 25.0413,2 c 3.553221,0 3.181125,8.844696 3.181125,8.844696 0,0 12.759141,-1.7066308 12.759141,2.936037 0,-1.131196 0.09575,-2.367327 -0.149194,-2.720297 C 39.072382,8.5244628 31.470576,2.8337474 28.725456,2.0879343 28.159884,2.0732543 25.606204,2.0292133 25.0413,2.0001473 Z"
+     id="path4474-6"
+     style="display:inline;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999998;font-variation-settings:normal;opacity:0.15;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
+  <path
+     d="m 25.0413,1.0000001 c 3.553221,0 3.181125,8.8446958 3.181125,8.8446958 0,0 12.759141,-1.7066306 12.759141,2.9360371 0,-1.131196 0.09575,-2.367327 -0.149194,-2.720297 C 39.072382,7.5244629 31.470576,1.8337475 28.725456,1.0879344 28.159884,1.0732544 25.606204,1.0292134 25.0413,1.0001474 Z"
+     id="path4474"
+     style="display:inline;fill:url(#linearGradient3078);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999998" />
+  <path
+     d="M 28.699326,1.5000002 C 29.948683,1.5000002 40.5,8.8393392 40.5,10.743633"
+     id="rect6741-1-2"
+     style="fill:none;stroke:url(#linearGradient5658);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+</svg>

--- a/data/io.elementary.mail.gresource.xml
+++ b/data/io.elementary.mail.gresource.xml
@@ -3,5 +3,10 @@
   <gresource prefix="/io/elementary/mail">
     <file alias="application.css" compressed="true">application.css</file>
     <file alias="blank-message-template.html" compressed="true">blank-message-template.html</file>
+
+    <file alias="16x16@2/places/mail-drafts.svg" compressed="true" preprocess="xml-stripblanks">icons/mail-drafts/16.svg</file>
+    <file alias="16x16/places/mail-drafts.svg" compressed="true" preprocess="xml-stripblanks">icons/mail-drafts/16.svg</file>
+    <file alias="48x48@2/places/mail-drafts.svg" compressed="true" preprocess="xml-stripblanks">icons/mail-drafts/48.svg</file>
+    <file alias="48x48/places/mail-drafts.svg" compressed="true" preprocess="xml-stripblanks">icons/mail-drafts/48.svg</file>
   </gresource>
 </gresources>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -82,6 +82,8 @@ public class Mail.Application : Gtk.Application {
 
     public override void activate () {
         if (main_window == null) {
+            Gtk.IconTheme.get_default ().add_resource_path ("/io/elementary/mail");
+
             main_window = new MainWindow (this);
 
             int window_x, window_y;

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -560,13 +560,15 @@ public class Mail.ComposerWidget : Gtk.Grid {
     }
 
     private void on_discard () {
-        var discard_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+        var discard_dialog = new Granite.MessageDialog (
             _("Permanently delete this draft?"),
             _("You cannot undo this action, nor recover your draft once it has been deleted."),
-            "dialog-warning",
+            new ThemedIcon ("mail-drafts"),
             Gtk.ButtonsType.NONE
-        );
-        discard_dialog.transient_for = get_toplevel () as Gtk.Window;
+        ) {
+            badge_icon = new ThemedIcon ("edit-delete"),
+            transient_for = get_toplevel () as Gtk.Window
+        };
 
         discard_dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
 

--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -79,7 +79,7 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
                 badge = null;
                 break;
             case Camel.FolderInfoFlags.TYPE_DRAFTS:
-                icon = new ThemedIcon ("folder-documents");
+                icon = new ThemedIcon ("mail-drafts");
                 can_modify = false;
                 break;
             default:


### PR DESCRIPTION
Thought it would be nice to use a badged icon for dialogs here and I noticed that we don't have a 48px drafts icon and we were actually using folder-documents for drafts. So gresource some specific icons

![Screenshot from 2021-07-08 10 28 36](https://user-images.githubusercontent.com/7277719/124966241-ee113580-dfd7-11eb-9699-2dcd1cdb83ca.png)
