### PR TITLE
Fixes #608: Random crash when changing folder

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -232,21 +232,21 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             if (current_search_query == null) {
                 return folders[service_uid].get_uids ();
             }
-    
+
             var sb = new StringBuilder ();
             Camel.SExp.encode_string (sb, current_search_query);
             var encoded_query = sb.str;
-    
+
             string search_query = """(match-all (or (header-contains "From" %s)(header-contains "Subject" %s)(body-contains %s)))"""
                 .printf (encoded_query, encoded_query, encoded_query);
-    
+
             try {
                 return folders[service_uid].search_by_expression (search_query, cancellable);
             } catch (Error e) {
                 if (!(e is GLib.IOError.CANCELLED)) {
                     warning ("Error while searching: %s", e.message);
                 }
-    
+
                 return folders[service_uid].get_uids ();
             }
         }

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -143,23 +143,26 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
                             try {
                                 var folder = yield ((Camel.Store) current_account.service).get_folder (current_full_name, 0, GLib.Priority.DEFAULT, cancellable);
-                                folder.changed.connect ((change_info) => folder_changed (change_info, current_account.service.uid, cancellable));
                                 folders[current_account.service.uid] = folder;
+                                folder.changed.connect ((change_info) => folder_changed (change_info, current_account.service.uid, cancellable));
 
-                                var thread = new Camel.FolderThread (folder, get_search_result_uids (current_account.service.uid), false);
-                                threads[current_account.service.uid] = thread;
+                                var search_result_uids = get_search_result_uids (current_account.service.uid);
+                                if (search_result_uids != null) {
+                                    var thread = new Camel.FolderThread (folder, search_result_uids, false);
+                                    threads[current_account.service.uid] = thread;
 
-                                unowned Camel.FolderThreadNode? child = (Camel.FolderThreadNode?) thread.tree;
-                                while (child != null) {
-                                    if (cancellable.is_cancelled ()) {
-                                        break;
+                                    unowned Camel.FolderThreadNode? child = (Camel.FolderThreadNode?) thread.tree;
+                                    while (child != null) {
+                                        if (cancellable.is_cancelled ()) {
+                                            break;
+                                        }
+
+                                        add_conversation_item (child, current_account.service.uid);
+                                        child = (Camel.FolderThreadNode?) child.next;
                                     }
 
-                                    add_conversation_item (child, current_account.service.uid);
-                                    child = (Camel.FolderThreadNode?) child.next;
+                                    yield folder.refresh_info (GLib.Priority.DEFAULT, cancellable);
                                 }
-
-                                yield folder.refresh_info (GLib.Priority.DEFAULT, cancellable);
 
                             } catch (Error e) {
                                 // We can cancel the operation
@@ -183,7 +186,12 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         lock (conversations) {
             lock (threads) {
-                threads[service_uid].apply (get_search_result_uids (service_uid));
+                var search_result_uids = get_search_result_uids (service_uid);
+                if (search_result_uids == null) {
+                    return;
+                }
+                threads[service_uid].apply (search_result_uids);
+
                 var removed = 0;
                 change_info.get_removed_uids ().foreach ((uid) => {
                     var item = conversations[uid];
@@ -215,26 +223,32 @@ public class Mail.ConversationListBox : VirtualizingListBox {
         }
     }
 
-    private GenericArray<string> get_search_result_uids (string service_uid) {
-        if (current_search_query == null) {
-            return folders[service_uid].get_uids ();
-        }
-
-        var sb = new StringBuilder ();
-        Camel.SExp.encode_string (sb, current_search_query);
-        var encoded_query = sb.str;
-
-        string search_query = """(match-all (or (header-contains "From" %s)(header-contains "Subject" %s)(body-contains %s)))"""
-            .printf (encoded_query, encoded_query, encoded_query);
-
-        try {
-            return folders[service_uid].search_by_expression (search_query, cancellable);
-        } catch (Error e) {
-            if (!(e is GLib.IOError.CANCELLED)) {
-                warning ("Error while searching: %s", e.message);
+    private GenericArray<string>? get_search_result_uids (string service_uid) {
+        lock (folders) {
+            if (folders[service_uid] == null) {
+                return null;
             }
 
-            return folders[service_uid].get_uids ();
+            if (current_search_query == null) {
+                return folders[service_uid].get_uids ();
+            }
+    
+            var sb = new StringBuilder ();
+            Camel.SExp.encode_string (sb, current_search_query);
+            var encoded_query = sb.str;
+    
+            string search_query = """(match-all (or (header-contains "From" %s)(header-contains "Subject" %s)(body-contains %s)))"""
+                .printf (encoded_query, encoded_query, encoded_query);
+    
+            try {
+                return folders[service_uid].search_by_expression (search_query, cancellable);
+            } catch (Error e) {
+                if (!(e is GLib.IOError.CANCELLED)) {
+                    warning ("Error while searching: %s", e.message);
+                }
+    
+                return folders[service_uid].get_uids ();
+            }
         }
     }
 


### PR DESCRIPTION
The crash described in #608 is caused by some asynchronous voodoo, where `folders[service_uid]` is already freed at the time when `get_search_result_uids ()` tries to access it.

This PR mitigates the issue by adding the following safety measures:

1. Set `folders[service_uid] = folder` before binding to folder.changed signal - just to be sure (swapped lines 146 and 147)
2. get_search_result_uids function locks the `folders` HashMap during its executing to prevent changes
3. get_search_result_uids function checks for existence of `folders[service_uid]` - if it does not exists, it returns `null`
4. Callers of the get_search_result_uids function handle the `null` case gracefully