### PR TITLE
Fix MailBackendSimpleSasl has an empty CamelServiceAuthType

### DIFF
--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -19,22 +19,19 @@
  */
 
 public class Mail.Backend.SimpleSasl : Camel.Sasl {
-    [CCode (cname = "auth_type")]
-    public Camel.ServiceAuthType auth_type;
+    private static Camel.ServiceAuthType simple_auth_type = {
+        N_("SimpleServiceAuthType"),
+        N_("Provides a way to fall back to passwords in SSO scenarios."),
+        "SIMPLESERVICEAUTHTYPE",
+        false
+    };
 
     public SimpleSasl (string service_name, string mechanism, Camel.Service service) {
         Object (service_name: service_name, mechanism: mechanism, service: service);
     }
 
-    construct {
-        auth_type = (Camel.ServiceAuthType) new SimpleServiceAuthType ();
-    }
-
-    private class SimpleServiceAuthType {
-        public string name = "SimpleServiceAuthType";
-        public string description = "Provides a way to fall back to passwords in SSO scenarios.";
-        public string authproto = "SIMPLESERVICEAUTHTYPE";
-        public bool need_password = false;
+    static construct {
+        auth_type = simple_auth_type;
     }
 }
 
@@ -99,7 +96,6 @@ public class Mail.Backend.Session : Camel.Session {
         /* Do not chain up.  Camel's default method is only an example for
          * subclasses to follow.  Instead we mimic most of its logic here. */
 
-        Camel.ServiceAuthType authtype;
         bool try_empty_password = false;
         var result = Camel.AuthenticationResult.REJECTED;
 
@@ -110,7 +106,7 @@ public class Mail.Backend.Session : Camel.Session {
         if (mechanism != null) {
             /* APOP is one case where a non-SASL mechanism name is passed, so
              * don't bail if the CamelServiceAuthType struct comes back NULL. */
-            authtype = Camel.Sasl.authtype (mechanism);
+            unowned var authtype = Camel.Sasl.authtype (mechanism);
 
             /* If the SASL mechanism does not involve a user
              * password, then it gets one shot to authenticate. */

--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -19,8 +19,22 @@
  */
 
 public class Mail.Backend.SimpleSasl : Camel.Sasl {
+    [CCode (cname = "auth_type")]
+    public Camel.ServiceAuthType auth_type;
+
     public SimpleSasl (string service_name, string mechanism, Camel.Service service) {
         Object (service_name: service_name, mechanism: mechanism, service: service);
+    }
+
+    construct {
+        auth_type = (Camel.ServiceAuthType) new SimpleServiceAuthType ();
+    }
+
+    private class SimpleServiceAuthType {
+        public string name = "SimpleServiceAuthType";
+        public string description = "Provides a way to fall back to passwords in SSO scenarios.";
+        public string authproto = "SIMPLESERVICEAUTHTYPE";
+        public bool need_password = false;
     }
 }
 

--- a/vapi/camel-1.2.vapi
+++ b/vapi/camel-1.2.vapi
@@ -1568,10 +1568,11 @@ namespace Camel {
 	}
 	[CCode (cheader_filename = "camel/camel.h", type_id = "camel_sasl_get_type ()")]
 	public abstract class Sasl : GLib.Object {
+		public class weak Camel.ServiceAuthType? auth_type;
 		[CCode (has_construct_function = false)]
 		protected Sasl ();
-		public static Camel.ServiceAuthType authtype (string mechanism);
-		public static GLib.List<weak Camel.ServiceAuthType> authtype_list (bool include_plain);
+		public static unowned Camel.ServiceAuthType? authtype (string mechanism);
+		public static GLib.List<weak Camel.ServiceAuthType?> authtype_list (bool include_plain);
 		[Version (since = "3.0")]
 		public async GLib.ByteArray challenge (GLib.ByteArray token, int io_priority, GLib.Cancellable? cancellable) throws GLib.Error;
 		[Version (since = "3.0")]
@@ -1700,8 +1701,8 @@ namespace Camel {
 		[Version (since = "3.2")]
 		public Camel.URL new_camel_url ();
 		[Version (since = "3.2")]
-		public async GLib.List<weak Camel.ServiceAuthType> query_auth_types (int io_priority, GLib.Cancellable? cancellable) throws GLib.Error;
-		public virtual GLib.List<weak Camel.ServiceAuthType> query_auth_types_sync (GLib.Cancellable? cancellable = null) throws GLib.Error;
+		public async GLib.List<weak Camel.ServiceAuthType?> query_auth_types (int io_priority, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		public virtual GLib.List<weak Camel.ServiceAuthType?> query_auth_types_sync (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "3.12")]
 		public void queue_task (GLib.Task task, [CCode (scope = "async")] GLib.TaskThreadFunc task_func);
 		[Version (since = "3.12")]
@@ -1729,18 +1730,6 @@ namespace Camel {
 		[NoAccessorMethod]
 		public Camel.Settings settings { owned get; set construct; }
 		public string uid { get; construct; }
-	}
-	[CCode (cheader_filename = "camel/camel.h", copy_function = "g_boxed_copy", free_function = "g_boxed_free", type_id = "camel_service_auth_type_get_type ()")]
-	[Compact]
-	public class ServiceAuthType {
-		public weak string authproto;
-		public weak string description;
-		public weak string name;
-		public bool need_password;
-		[Version (since = "3.24")]
-		public Camel.ServiceAuthType copy ();
-		[Version (since = "3.24")]
-		public void free ();
 	}
 	[CCode (cheader_filename = "camel/camel.h", type_id = "camel_session_get_type ()")]
 	public class Session : GLib.Object {
@@ -2546,6 +2535,17 @@ namespace Camel {
 		public void*[] value_func_terms;
 		[CCode (cname = "value.func.termcount")]
 		public int value_func_termcount;
+	}
+	[CCode (cheader_filename = "camel/camel.h", copy_function = "g_boxed_copy", free_function = "g_boxed_free", type_id = "camel_service_auth_type_get_type ()")]
+	public struct ServiceAuthType {
+		public weak string name;
+		public weak string description;
+		public weak string authproto;
+		public bool need_password;
+		[Version (since = "3.24")]
+		public Camel.ServiceAuthType? copy ();
+		[Version (since = "3.24")]
+		public void free ();
 	}
 	[CCode (cheader_filename = "camel/camel.h", has_type_id = false)]
 	public struct StoreInfo {


### PR DESCRIPTION
This PR attempts to fix the critical message printed at the startup of Mail:

```
(io.elementary.mail:6659): camel-CRITICAL **: 11:20:27.758: MailBackendSimpleSasl has an empty CamelServiceAuthType
```

Which is caused by the following line in EDS: https://gitlab.gnome.org/GNOME/evolution-data-server/-/blob/master/src/camel/camel-sasl.c#L103

However, I'm stuck: Because I can't subclass `Camel.ServiceAuthType`, I simply cast the newly added `SimpleServiceAuthType` to `Camel.ServiceAuthType` which works just fine. However, EDS is still throwing the critical message. @tintou what I'm missing here?