### PR TITLE
Fix #619: Don't save draft if no changes were made

### DIFF
--- a/data/io.elementary.mail.appdata.xml.in
+++ b/data/io.elementary.mail.appdata.xml.in
@@ -26,6 +26,7 @@
       <description>
         <p>Improvements:</p>
         <ul>
+          <li>Only save drafts when there are new changes</li>
           <li>Move Undo notification to the message view</li>
           <li>Updated translations</li>
         </ul>

--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -890,7 +890,7 @@ public class Mail.ComposerWidget : Gtk.Grid {
     }
 
     public override void destroy () {
-        if (discard_draft) {
+        if (discard_draft || !web_view.body_html_changed) {
             base.destroy ();
             return;
         }

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -26,6 +26,8 @@ public class Mail.WebView : WebKit.WebView {
     public signal void selection_changed ();
     public signal void load_finished ();
 
+    public bool body_html_changed { get; private set; default = false; }
+
     private const string INTERNAL_URL_BODY = "elementary-mail:body";
     private const string SERVER_BUS_NAME = "io.elementary.mail.WebViewServer";
 
@@ -59,6 +61,10 @@ public class Mail.WebView : WebKit.WebView {
 
         decide_policy.connect (on_decide_policy);
         load_changed.connect (on_load_changed);
+
+        key_release_event.connect (() => {
+            body_html_changed = true;
+        });
     }
 
     public WebView () {
@@ -178,6 +184,7 @@ public class Mail.WebView : WebKit.WebView {
     public void execute_editor_command (string command, string argument = "") {
         var message = new WebKit.UserMessage ("execute-editor-command", new Variant ("(ss)", command, argument));
         send_message_to_page.begin (message, cancellable);
+        body_html_changed = true;
     }
 
     public async bool query_command_state (string command) {


### PR DESCRIPTION
This is a naive approach to detect changes made to a draft or a newly created message. It simply sets the changed flag whenever a key was pressed in the composer or a command was executed (bold, italic etc.)

Although this is not 100% correct at all times, it seems to work well enough - and I did not found any better solution.