### PR TITLE
Set SEEN flag on draft

### DIFF
--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -524,7 +524,7 @@ public class Mail.Backend.Session : Camel.Session {
             throw new Camel.StoreError.NO_FOLDER ("Unable to connect to drafts folder.");
         }
 
-        var message_info = new MessageInfo (Camel.MessageFlags.DRAFT);
+        var message_info = new MessageInfo (Camel.MessageFlags.DRAFT | Camel.MessageFlags.SEEN);
         yield drafts_folder.append_message (message, message_info, 0, null, null);
 
         if (ancestor_message_info != null && Camel.MessageFlags.DRAFT in (int) ancestor_message_info.flags) {


### PR DESCRIPTION
Not 100% sure about this:

We probably want drafts to be displayed as "seen" in the conversation list - but still display the amount of drafts stored next to the draft's folder name (regardless if "seen" or not - just the total amount of drafts).

Thoughts?