### PR TITLE
README: Removed Evolution account setup hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,3 @@ To install, use `ninja install`, then execute with `io.elementary.mail`
     io.elementary.mail
 
 You might want to set the `WEBKIT_EXTENSION_PATH` environment variable to the `webkit-extension` build folder in order to test the application without installing it
-
-## Connecting Your Account
-
-Mail uses Evolution Data Server and Camel to display your emails. Currently, the easiset way to test Mail with your accounts is to set up them up in Evolution first. Ultimately, setting up an account in Online Accounts will connect it to EDS/Camel but that has not yet been implemented.


### PR DESCRIPTION
Because on Odin this is no longer valid. Online Accounts now allows for setting up the mail account.

Was brought up in https://github.com/elementary/mail/issues/650#issuecomment-902275359