### PR TITLE
Fix #582: Calculate the page height correctly

### DIFF
--- a/webkit-extension/MailPage.vala
+++ b/webkit-extension/MailPage.vala
@@ -46,7 +46,12 @@ public class Mail.Page : Object {
                 message.send_reply (new WebKit.UserMessage ("get-body-html", new Variant.take_string (val.to_string ())));
                 return true;
             case "get-page-height":
-                JSC.Value val = js_context.evaluate ("document.documentElement.offsetHeight;", -1);
+                JSC.Value val = js_context.evaluate ("""
+                Math.max(
+                    document.body.scrollHeight, document.body.offsetHeight,
+                    document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight
+                );
+                """, -1);
                 message.send_reply (new WebKit.UserMessage ("get-page-height", new Variant.int32 (val.to_int32 ())));
                 return true;
             case "set-image-loading-enabled":


### PR DESCRIPTION
This PR fixes #582 by correctly calculating the page height of an email as the previously used method failed under certain circumstances.

We now just use the max height available. Solution inspired by this StackOverflow post: https://stackoverflow.com/questions/1145850/how-to-get-height-of-entire-document-with-javascript#answer-1147768