### PR TITLE
Cache timestamp to avoid compare_func from crashing

### DIFF
--- a/src/ConversationList/ConversationItemModel.vala
+++ b/src/ConversationList/ConversationItemModel.vala
@@ -24,6 +24,8 @@ public class Mail.ConversationItemModel : GLib.Object {
     public string service_uid { get; construct; }
     public Camel.FolderThreadNode? node;
 
+    private int64 _timestamp;
+
     public string formatted_date {
         owned get {
             return Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (timestamp));
@@ -153,7 +155,7 @@ public class Mail.ConversationItemModel : GLib.Object {
 
     public int64 timestamp {
         get {
-            return get_newest_timestamp (node);
+            return _timestamp;
         }
     }
 
@@ -164,6 +166,8 @@ public class Mail.ConversationItemModel : GLib.Object {
 
     public void update_node (Camel.FolderThreadNode new_node) {
         node = new_node;
+
+        _timestamp = get_newest_timestamp (new_node, -1);
     }
 
     private static uint count_thread_messages (Camel.FolderThreadNode node) {

--- a/src/ConversationList/ConversationItemModel.vala
+++ b/src/ConversationList/ConversationItemModel.vala
@@ -24,8 +24,6 @@ public class Mail.ConversationItemModel : GLib.Object {
     public string service_uid { get; construct; }
     public Camel.FolderThreadNode? node;
 
-    private int64 _timestamp;
-
     public string formatted_date {
         owned get {
             return Granite.DateTime.get_relative_datetime (new DateTime.from_unix_local (timestamp));
@@ -153,11 +151,7 @@ public class Mail.ConversationItemModel : GLib.Object {
         }
     }
 
-    public int64 timestamp {
-        get {
-            return _timestamp;
-        }
-    }
+    public int64 timestamp { get; private set; }
 
     public ConversationItemModel (Camel.FolderThreadNode node, string service_uid) {
         Object (service_uid: service_uid);
@@ -166,8 +160,7 @@ public class Mail.ConversationItemModel : GLib.Object {
 
     public void update_node (Camel.FolderThreadNode new_node) {
         node = new_node;
-
-        _timestamp = get_newest_timestamp (new_node, -1);
+        timestamp = get_newest_timestamp (new_node, -1);
     }
 
     private static uint count_thread_messages (Camel.FolderThreadNode node) {


### PR DESCRIPTION
Avoids using freed nodes when `ConversationListStore` uses it's `compare_func`.

Fixed the `camel_message_info_get_date_received: assertion 'CAMEL_IS_MESSAGE_INFO (mi)' failed` errors for me (#649, #650 , #652).

Note: `folder_changed` updates *every* conversation in the folder, so is expensive when a folder has a large number of items. So for example, setting a message as read will ultimately mean `folder_changed` fires and touches every conversation. I can't see a way around it at the moment though.