### PR TITLE
MessageListBox: Hide other children while InlineComposer is shown

### DIFF
--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -98,10 +98,16 @@ public class Mail.MessageListBox : Gtk.ListBox {
     }
 
     public async void add_inline_composer (ComposerWidget.Type type, MessageListItem? message_item = null) {
+        var children = get_children ();
+
         /* Can't open a new composer if thread is empty or currently has a composer open */
-        var last_child = get_row_at_index ((int) get_children ().length () - 1);
+        var last_child = get_row_at_index ((int) children.length () - 1);
         if (last_child == null || last_child is InlineComposer) {
             return;
+        }
+
+        foreach (var child in children) {
+            child.hide ();
         }
 
         if (message_item == null) {
@@ -121,6 +127,10 @@ public class Mail.MessageListBox : Gtk.ListBox {
             can_move_thread = true;
             remove (composer);
             composer.destroy ();
+
+            foreach (var child in get_children ()) {
+                child.show ();
+            }
         });
         add (composer);
         can_reply = false;


### PR DESCRIPTION
This PR is related to https://github.com/elementary/mail/issues/671 where I accidentally changed the sender address while scrolling.

We fix the weird scrolling behavior here by hiding other messages while the InlineComposer is shown.

**Before**

https://user-images.githubusercontent.com/392542/131533890-aa445f52-f175-4a26-96a6-44fb629bf919.mp4

**After**

https://user-images.githubusercontent.com/392542/131533915-62b68fd1-d44d-43ed-9751-0c889bfb8312.mp4

