### PR TITLE
Meson: rename daemon and remove config

### DIFF
--- a/data/daemon.desktop
+++ b/data/daemon.desktop
@@ -3,7 +3,6 @@ Name=Mail Daemon
 Comment=Send and receive mail
 Exec=io.elementary.mail --background
 Icon=io.elementary.mail
-Keywords=Email;E-mail;Mail;
 Terminal=false
 Type=Application
 NoDisplay=true

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,12 +13,10 @@ foreach i : icon_sizes
     )
 endforeach
 
-daemon_desktop_config = configuration_data()
-configure_file(
-    input: meson.project_name() + '-daemon.desktop.in',
-    output: meson.project_name() + '-daemon.desktop',
-    configuration: daemon_desktop_config,
-    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+install_data(
+    'daemon.desktop',
+    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart'),
+    rename: meson.project_name() + '-daemon.desktop'
 )
 
 install_data(


### PR DESCRIPTION
Since we're not doing anything fancy, I don't think we need that `config` step

Also, I don't think we need keywords here since autostart files aren't searchable afaik

Simplify the file name while we're here because meson lets us do that and it's convenient finding the right file in the sidebar of Code