### PR TITLE
Avoid storing to "Sent" twice for outlook.com

### DIFF
--- a/data/io.elementary.mail.appdata.xml.in
+++ b/data/io.elementary.mail.appdata.xml.in
@@ -29,6 +29,7 @@
           <li>Send a notification when new messages arrive</li>
           <li>Improve search performance</li>
           <li>Filter unread or starred conversations</li>
+          <li>Make sure we don't save sent messages twice for outlook.com accounts</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -387,7 +387,8 @@ public class Mail.Backend.Session : Camel.Session {
             if (
                 E.util_utf8_strstrcase (transport_auth_extension.host, ".gmail.com") != null ||
                 E.util_utf8_strstrcase (transport_auth_extension.host, ".googlemail.com") != null ||
-                E.util_utf8_strstrcase (transport_auth_extension.host, ".office365.com") != null
+                E.util_utf8_strstrcase (transport_auth_extension.host, ".office365.com") != null ||
+                E.util_utf8_strstrcase (transport_auth_extension.host, ".outlook.com") != null
             ) {
                 /*
                  * Skip appending to Sent folder for GMail and Office 365, because both store sent messages


### PR DESCRIPTION
Follow up of https://github.com/elementary/mail/pull/625. Fixes https://github.com/elementary/mail/issues/465

@danrabbit would be great to get this released by end of this month too :)