### PR TITLE
Add conversation list context menu

### DIFF
--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -103,7 +103,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             }
         });
 
-        button_press_event.connect ((e) => {
+        button_release_event.connect ((e) => {
 
             if (e.button != Gdk.BUTTON_SECONDARY) {
                 return Gdk.EVENT_PROPAGATE;
@@ -118,7 +118,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             return create_context_menu (e, (ConversationListItem)row);
         });
 
-        key_press_event.connect ((e) => {
+        key_release_event.connect ((e) => {
 
             if (e.keyval != Gdk.Key.Menu) {
                 return Gdk.EVENT_PROPAGATE;
@@ -457,15 +457,17 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         var menu = new Gtk.Menu ();
 
-        var delete_menu_item = new Gtk.MenuItem.with_label (_("Delete"));
-        menu.add (delete_menu_item);
+        var trash_menu_item = new Gtk.MenuItem ();
+        trash_menu_item.add (new Granite.AccelLabel.from_action_name (_("Move To Trash"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MOVE_TO_TRASH));
+        menu.add (trash_menu_item);
 
-        delete_menu_item.activate.connect (() => {
+        trash_menu_item.activate.connect (() => {
             trash_selected_messages ();
         });
 
         if (!item.unread) {
-            var mark_unread_menu_item = new Gtk.MenuItem.with_label (_("Mark As Unread"));
+            var mark_unread_menu_item = new Gtk.MenuItem ();
+            mark_unread_menu_item.add (new Granite.AccelLabel.from_action_name(_("Mark As Unread"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNREAD));
             menu.add (mark_unread_menu_item);
 
             mark_unread_menu_item.activate.connect (() => {
@@ -473,7 +475,8 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             });
 
         } else {
-            var mark_read_menu_item = new Gtk.MenuItem.with_label (_("Mark As Read"));
+            var mark_read_menu_item = new Gtk.MenuItem ();
+            mark_read_menu_item.add (new Granite.AccelLabel.from_action_name(_("Mark as Read"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_READ));
             menu.add (mark_read_menu_item);
 
             mark_read_menu_item.activate.connect (() => {
@@ -482,14 +485,16 @@ public class Mail.ConversationListBox : VirtualizingListBox {
         }
 
         if (!item.flagged) {
-            var mark_starred_menu_item = new Gtk.MenuItem.with_label (_("Mark As Starred"));
+            var mark_starred_menu_item = new Gtk.MenuItem ();
+            mark_starred_menu_item.add (new Granite.AccelLabel.from_action_name(_("Star"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_STAR));
             menu.add (mark_starred_menu_item);
 
             mark_starred_menu_item.activate.connect (() => {
                 mark_star_selected_messages ();
             });
         } else {
-            var mark_unstarred_menu_item = new Gtk.MenuItem.with_label (_("Unmark As Starred"));
+            var mark_unstarred_menu_item = new Gtk.MenuItem ();
+            mark_unstarred_menu_item.add (new Granite.AccelLabel.from_action_name(_("Unstar"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNSTAR));
             menu.add (mark_unstarred_menu_item);
 
             mark_unstarred_menu_item.activate.connect (() => {
@@ -499,10 +504,10 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         menu.show_all ();
 
-        if (e.type == Gdk.EventType.BUTTON_PRESS) {
+        if (e.type == Gdk.EventType.BUTTON_RELEASE) {
             menu.popup_at_pointer (e);
             return Gdk.EVENT_STOP;
-        } else if (e.type == Gdk.EventType.KEY_PRESS) {
+        } else if (e.type == Gdk.EventType.KEY_RELEASE) {
             menu.popup_at_widget (row, Gdk.Gravity.EAST, Gdk.Gravity.CENTER, e);
             return Gdk.EVENT_STOP;
         }

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -467,7 +467,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         if (!item.unread) {
             var mark_unread_menu_item = new Gtk.MenuItem ();
-            mark_unread_menu_item.add (new Granite.AccelLabel.from_action_name(_("Mark As Unread"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNREAD));
+            mark_unread_menu_item.add (new Granite.AccelLabel.from_action_name (_("Mark As Unread"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNREAD));
             menu.add (mark_unread_menu_item);
 
             mark_unread_menu_item.activate.connect (() => {
@@ -476,7 +476,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         } else {
             var mark_read_menu_item = new Gtk.MenuItem ();
-            mark_read_menu_item.add (new Granite.AccelLabel.from_action_name(_("Mark as Read"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_READ));
+            mark_read_menu_item.add (new Granite.AccelLabel.from_action_name (_("Mark as Read"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_READ));
             menu.add (mark_read_menu_item);
 
             mark_read_menu_item.activate.connect (() => {
@@ -486,7 +486,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         if (!item.flagged) {
             var mark_starred_menu_item = new Gtk.MenuItem ();
-            mark_starred_menu_item.add (new Granite.AccelLabel.from_action_name(_("Star"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_STAR));
+            mark_starred_menu_item.add (new Granite.AccelLabel.from_action_name (_("Star"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_STAR));
             menu.add (mark_starred_menu_item);
 
             mark_starred_menu_item.activate.connect (() => {
@@ -494,7 +494,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
             });
         } else {
             var mark_unstarred_menu_item = new Gtk.MenuItem ();
-            mark_unstarred_menu_item.add (new Granite.AccelLabel.from_action_name(_("Unstar"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNSTAR));
+            mark_unstarred_menu_item.add (new Granite.AccelLabel.from_action_name (_("Unstar"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNSTAR));
             menu.add (mark_unstarred_menu_item);
 
             mark_unstarred_menu_item.activate.connect (() => {

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -111,7 +111,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
             var row = get_row_at_y ((int)e.y);
 
-            if (!get_selected_rows().contains (row)) {
+            if (selected_row_widget != row) {
                 select_row (row);
             }
 

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -93,7 +93,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
             var item = selected_row;
 
             foreach (var child in current_widgets) {
-                if(child.model_item == item) {
+                if (child.model_item == item) {
                     return (VirtualizingListBoxRow)child;
                 }
             }

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -664,7 +664,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
 
         if (selection_mode == Gtk.SelectionMode.BROWSE) {
-            select_row_internal (row);
+            select_row (row);
         } else if (selection_mode == Gtk.SelectionMode.SINGLE) {
             var was_selected = model.get_item_selected (row.model_item);
             unselect_all_internal ();
@@ -683,7 +683,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
                 var selected = selected_row;
                 unselect_all_internal ();
                 if (selected == null) {
-                    select_row_internal (row);
+                    select_row (row);
                 } else {
                     select_all_between (selected, row.model_item, false);
                 }
@@ -699,7 +699,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
                     model.set_item_selected (row.model_item, !selected);
                 } else {
                     unselect_all_internal ();
-                    select_row_internal (row);
+                    select_row (row);
                 }
             }
         }
@@ -727,7 +727,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
     }
 
     private void select_and_activate (VirtualizingListBoxRow row, bool grab_focus = true) {
-        select_row_internal (row);
+        select_row (row);
         update_cursor (row.model_item, grab_focus);
         row_activated (row.model_item);
     }
@@ -784,10 +784,6 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
     }
 
     protected void select_row (VirtualizingListBoxRow row) {
-        select_row_internal (row);
-    }
-
-    private void select_row_internal (VirtualizingListBoxRow row) {
         if (model.get_item_selected (row) || selection_mode == Gtk.SelectionMode.NONE) {
             return;
         }

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -88,6 +88,20 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
     }
 
+    public VirtualizingListBoxRow? selected_row_widget {
+        get {
+            var item = selected_row;
+
+            foreach (var child in current_widgets) {
+                if(child.model_item == item) {
+                    return (VirtualizingListBoxRow)child;
+                }
+            }
+
+            return null;
+        }
+    }
+
     public Gtk.Adjustment hadjustment { get; set; }
     public Gtk.ScrollablePolicy hscroll_policy { get; set; }
     public Gtk.ScrollablePolicy vscroll_policy { get; set; }
@@ -767,6 +781,10 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
 
         return null;
+    }
+
+    protected void select_row (VirtualizingListBoxRow row) {
+        select_row_internal (row);
     }
 
     private void select_row_internal (VirtualizingListBoxRow row) {


### PR DESCRIPTION
Adds a context menu for the single selected conversation.

If we ever support multi-select, this will require some slight refactoring (mainly, to resolve the "state" of the multiple selected items).