### PR TITLE
Use local time in the message header

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -170,7 +170,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         var time_format = Granite.DateTime.get_default_time_format (desktop_settings.get_enum ("clock-format") == 1, false);
 
         ///TRANSLATORS: The first %s represents the date and the second %s the time of the message (either when it was received or sent)
-        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).format (_("%s at %s").printf (date_format, time_format)));
+        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).to_local ().format (_("%s at %s").printf (date_format, time_format)));
         datetime_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         var starred_icon = new Gtk.Image ();


### PR DESCRIPTION
Message header currently shows formatted time in UTC.

This adjusts the time to be local to the OS time zone.