### PR TITLE
Fix regression: Make sure we show composer if session was already started

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -80,9 +80,14 @@ public class Mail.Application : Gtk.Application {
 
                 to = Soup.URI.decode (mailto.path);
 
-                main_window.session_started.connect (() => {
+                if (main_window.is_session_started) {
                     new ComposerWindow (main_window, to, mailto.query).show_all ();
-                });
+
+                } else {
+                    main_window.session_started.connect (() => {
+                        new ComposerWindow (main_window, to, mailto.query).show_all ();
+                    });
+                }
 
             } catch (OptionError e) {
                 warning ("Argument parsing error. %s", e.message);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -39,6 +39,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     private uint configure_id;
     private uint search_changed_debounce_timeout_id = 0;
 
+    public bool is_session_started { get; private set; default = false; }
     public signal void session_started ();
 
     public const string ACTION_GROUP_PREFIX = "win";
@@ -318,6 +319,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         session.start.begin ((obj, res) => {
             session.start.end (res);
+            is_session_started = true;
             session_started ();
         });
     }


### PR DESCRIPTION
This PR f*xes the issue described by @Marukesu [here](https://github.com/elementary/files/pull/1822#issuecomment-944524976). This regression was introduced by https://github.com/elementary/mail/pull/718