### PR TITLE
avoid assertion error in `add_internal_resource` when `content_id` is…

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -578,7 +578,9 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
     }
 
     private async void handle_inline_mime (Camel.MimePart part) {
-        if (part.get_content_id () == null) { return; }
+        if (part.get_content_id () == null) {
+            return;
+        }
 
         var byte_array = new ByteArray ();
         var os = new Camel.StreamMem ();

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -578,19 +578,21 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
     }
 
     private async void handle_inline_mime (Camel.MimePart part) {
-        var byte_array = new ByteArray ();
-        var os = new Camel.StreamMem ();
-        os.set_byte_array (byte_array);
-        try {
-            yield part.content.decode_to_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
-        } catch (Error e) {
-            warning ("Error decoding inline attachment: %s", e.message);
-            return;
-        }
+        if (part.get_content_id () != null) {
+            var byte_array = new ByteArray ();
+            var os = new Camel.StreamMem ();
+            os.set_byte_array (byte_array);
+            try {
+                yield part.content.decode_to_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
+            } catch (Error e) {
+                warning ("Error decoding inline attachment: %s", e.message);
+                return;
+            }
 
-        Bytes bytes = ByteArray.free_to_bytes (byte_array);
-        var inline_stream = new MemoryInputStream.from_bytes (bytes);
-        web_view.add_internal_resource (part.get_content_id (), inline_stream);
+            Bytes bytes = ByteArray.free_to_bytes (byte_array);
+            var inline_stream = new MemoryInputStream.from_bytes (bytes);
+            web_view.add_internal_resource (part.get_content_id (), inline_stream);
+        }
     }
 
     public async string get_message_body_html () {

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -578,21 +578,21 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
     }
 
     private async void handle_inline_mime (Camel.MimePart part) {
-        if (part.get_content_id () != null) {
-            var byte_array = new ByteArray ();
-            var os = new Camel.StreamMem ();
-            os.set_byte_array (byte_array);
-            try {
-                yield part.content.decode_to_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
-            } catch (Error e) {
-                warning ("Error decoding inline attachment: %s", e.message);
-                return;
-            }
+        if (part.get_content_id () == null) { return; }
 
-            Bytes bytes = ByteArray.free_to_bytes (byte_array);
-            var inline_stream = new MemoryInputStream.from_bytes (bytes);
-            web_view.add_internal_resource (part.get_content_id (), inline_stream);
+        var byte_array = new ByteArray ();
+        var os = new Camel.StreamMem ();
+        os.set_byte_array (byte_array);
+        try {
+            yield part.content.decode_to_stream (os, GLib.Priority.DEFAULT, loading_cancellable);
+        } catch (Error e) {
+            warning ("Error decoding inline attachment: %s", e.message);
+            return;
         }
+
+        Bytes bytes = ByteArray.free_to_bytes (byte_array);
+        var inline_stream = new MemoryInputStream.from_bytes (bytes);
+        web_view.add_internal_resource (part.get_content_id (), inline_stream);
     }
 
     public async string get_message_body_html () {


### PR DESCRIPTION
I just put the whole block into a guarding `if`. The code change is minimal, but due to reindentation all the lines in the `if` are marked as changed :-(

I got the assertion triggered in a couple of emails and this change is an easy way to avoid the critical log but keeping the same functionality.

Probably also fixes the issue #697.