### PR TITLE
Fix UI freeze because of uint underflow

### DIFF
--- a/data/io.elementary.mail.appdata.xml.in
+++ b/data/io.elementary.mail.appdata.xml.in
@@ -27,6 +27,7 @@
         <p>Improvements:</p>
         <ul>
           <li>Use message subject for compose window title</li>
+          <li>Fix a freeze when archiving the last message in a folder</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -744,8 +744,13 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
             return null;
         }
 
-        var index_max = model.get_n_items () - 1;
-        if (index_max == uint.MAX || index > index_max) {
+        var n_items = model.get_n_items ();
+        if (n_items == 0) {
+            return null;
+        }
+
+        var index_max = n_items - 1;
+        if (index > index_max) {
             return null;
         }
 

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -740,13 +740,12 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
     }
 
     private VirtualizingListBoxRow? ensure_index_visible (int index) {
-        var index_max = model.get_n_items () - 1;
-
         if (index < 0) {
             return null;
         }
 
-        if (index > index_max) {
+        var index_max = model.get_n_items () - 1;
+        if (index_max == uint.MAX || index > index_max) {
             return null;
         }
 


### PR DESCRIPTION
This fixes https://github.com/elementary/mail/issues/734 caused by a regression introduced in https://github.com/elementary/mail/pull/717:

Basically when `model.get_n_items () ` returns `0` and we subtract `1` from it, we end up with an underflow because we are dealing with an `uint` here. So the result of this calculation is `uint.MAX`. The following code then starts to loop from `0` to `uint.MAX` multiple times causing my laptop to fly :smile: 

This PR introduces some changes to avoid this.