### PR TITLE
get_own_addresses return a unique list of email addresses

### DIFF
--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -312,7 +312,9 @@ public class Mail.Backend.Session : Camel.Session {
             }
 
             var address = extension.get_address ();
-            addresses.add (address.casefold ());
+            if (!addresses.contains (address.casefold ())) {
+              addresses.add (address.casefold ());
+            }
 
             var aliases = extension.get_aliases_as_hash_table ();
             if (aliases != null) {


### PR DESCRIPTION
In the Composer Widget, the `from` dropdown has duplicate entries, these duplicate come from `session.get_own_addresses`.
This solves the symptom by making `get_own_addresses` return a unique list of email addresses.

ref https://github.com/elementary/mail/issues/750