### PR TITLE
Fix FolderThreadNode use after free crash

### DIFF
--- a/src/ConversationList/ConversationItemModel.vala
+++ b/src/ConversationList/ConversationItemModel.vala
@@ -22,7 +22,9 @@
 
 public class Mail.ConversationItemModel : GLib.Object {
     public string service_uid { get; construct; }
-    public unowned Camel.FolderThreadNode? node;
+    public unowned Camel.FolderThreadNode? node { get; construct; }
+    public Camel.FolderThread thread { get; construct; }
+    public int64 timestamp { get; construct; }
 
     public string formatted_date {
         owned get {
@@ -146,20 +148,18 @@ public class Mail.ConversationItemModel : GLib.Object {
         }
     }
 
-    public int64 timestamp { get; private set; }
-
-    public ConversationItemModel (Camel.FolderThreadNode node, string service_uid) {
-        Object (service_uid: service_uid);
-        update_node (node);
+    public ConversationItemModel (Camel.FolderThreadNode node, Camel.FolderThread thread, string service_uid) {
+        Object (service_uid: service_uid, node: node, thread: thread);
     }
 
-    public bool update_node (Camel.FolderThreadNode new_node) {
-        node = new_node;
+    construct {
+        timestamp = get_newest_timestamp (node, -1);
+    }
 
-        var old_timestamp = timestamp;
-        timestamp = get_newest_timestamp (new_node, -1);
+    public bool is_older_than (Camel.FolderThreadNode other_node) {
+        var other_timestamp = get_newest_timestamp (other_node, -1);
 
-        return (old_timestamp != timestamp);
+        return (timestamp < other_timestamp);
     }
 
     private static uint count_thread_messages (Camel.FolderThreadNode node) {

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -194,7 +194,7 @@ public class Mail.ConversationListBox : VirtualizingListBox {
                                             break;
                                         }
 
-                                        add_conversation_item (child, current_account.service.uid);
+                                        add_conversation_item (child, thread, current_account.service.uid);
                                         child = child.next;
                                     }
                                 }
@@ -235,7 +235,6 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
         lock (conversations) {
             lock (threads) {
-                list_store.set_filter_func (null);
                 var search_result_uids = get_search_result_uids (service_uid);
                 if (search_result_uids == null) {
                     return;
@@ -261,20 +260,19 @@ public class Mail.ConversationListBox : VirtualizingListBox {
 
                     var item = conversations[child.message.uid];
                     if (item == null) {
-                        add_conversation_item (child, service_uid);
+                        add_conversation_item (child, threads[service_uid], service_uid);
                     } else {
-                        if (item.update_node (child)) {
+                        if (item.is_older_than (child)) {
                             conversations.unset (child.message.uid);
                             list_store.remove (item);
                             removed++;
-                            add_conversation_item (child, service_uid);
+                            add_conversation_item (child, threads[service_uid], service_uid);
                         };
                     }
 
                     child = child.next;
                 }
 
-                list_store.set_filter_func (filter_function);
                 list_store.items_changed (0, removed, list_store.get_n_items ());
             }
         }
@@ -332,8 +330,8 @@ public class Mail.ConversationListBox : VirtualizingListBox {
         yield load_folder (folder_full_name_per_account);
     }
 
-    private void add_conversation_item (Camel.FolderThreadNode child, string service_uid) {
-        var item = new ConversationItemModel (child, service_uid);
+    private void add_conversation_item (Camel.FolderThreadNode child, Camel.FolderThread thread, string service_uid) {
+        var item = new ConversationItemModel (child, thread, service_uid);
         conversations[child.message.uid] = item;
         list_store.add (item);
     }


### PR DESCRIPTION
We mitigate this crash by keeping a reference of the corresponding thread within ConversationItemModel. We also no longer update the node itself by external code without instantiating a new ConversationItemModel.

I _think_ this finally fixes the root cause for quite a few of the crash symptoms we ran into in the past:

- https://github.com/elementary/mail/issues/768
- https://github.com/elementary/mail/issues/700
- https://github.com/elementary/mail/issues/650
- https://github.com/elementary/mail/issues/649

That said, removing and re-adding the list filter is no longer necessary with this fix.