### PR TITLE
Show recipient in Sent folder instead of sender

### DIFF
--- a/data/io.elementary.mail.appdata.xml.in
+++ b/data/io.elementary.mail.appdata.xml.in
@@ -22,12 +22,13 @@
       <binary>io.elementary.mail</binary>
   </provides>
   <releases>
-  <release version="6.4.1" date="2022-02-06" urgency="medium">
+    <release version="6.4.1" date="2022-02-06" urgency="medium">
       <description>
         <p>Fixes:</p>
         <ul>
           <li>Display recipient in Sent folder instead of sender</li>
         </ul>
+      </description>
     </release>
     <release version="6.4.0" date="2022-01-22" urgency="medium">
       <description>

--- a/data/io.elementary.mail.appdata.xml.in
+++ b/data/io.elementary.mail.appdata.xml.in
@@ -22,6 +22,13 @@
       <binary>io.elementary.mail</binary>
   </provides>
   <releases>
+  <release version="6.4.1" date="2022-02-06" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Display recipient in Sent folder instead of sender</li>
+        </ul>
+    </release>
     <release version="6.4.0" date="2022-01-22" urgency="medium">
       <description>
         <p>New features:</p>

--- a/src/ConversationList/ConversationItemModel.vala
+++ b/src/ConversationList/ConversationItemModel.vala
@@ -23,7 +23,7 @@
 public class Mail.ConversationItemModel : GLib.Object {
     public string service_uid { get; construct; }
     public unowned Camel.FolderThreadNode? node;
-    public Camel.FolderInfoFlags folder_info_flags { get; construct; } 
+    public Camel.FolderInfoFlags folder_info_flags { get; construct; }
 
     public string formatted_date {
         owned get {

--- a/src/ConversationList/ConversationListItem.vala
+++ b/src/ConversationList/ConversationListItem.vala
@@ -88,8 +88,15 @@ public class Mail.ConversationListItem : VirtualizingListBoxRow {
     public void assign (ConversationItemModel data) {
         date.label = data.formatted_date;
         topic.label = data.subject;
-        source.label = GLib.Markup.escape_text (data.from);
-        tooltip_markup = GLib.Markup.printf_escaped ("<b>%s</b>\n%s", data.from, data.subject);
+
+        var source_label_text = "";
+        if (Camel.FolderInfoFlags.TYPE_SENT == (data.folder_info_flags & Camel.FOLDER_TYPE_MASK)) {
+            source_label_text = data.to;
+        } else {
+            source_label_text = data.from;
+        }
+        source.label = GLib.Markup.escape_text (source_label_text);
+        tooltip_markup = GLib.Markup.printf_escaped ("<b>%s</b>\n%s", source_label_text, data.subject);
 
         uint num_messages = data.num_messages;
         messages.label = num_messages > 1 ? "%u".printf (num_messages) : null;

--- a/src/FoldersView/FolderSourceItem.vala
+++ b/src/FoldersView/FolderSourceItem.vala
@@ -50,7 +50,7 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
             badge = "%d".printf (folderinfo.unread);
         }
 
-        var full_folder_info_flags = get_full_folder_info_flags (folderinfo);
+        var full_folder_info_flags = Utils.get_full_folder_info_flags (account.service, folderinfo);
         switch (full_folder_info_flags & Camel.FOLDER_TYPE_MASK) {
             case Camel.FolderInfoFlags.TYPE_INBOX:
                 icon = new ThemedIcon ("mail-inbox");
@@ -87,51 +87,5 @@ public class Mail.FolderSourceItem : Granite.Widgets.SourceList.ExpandableItem {
                 can_modify = true;
                 break;
         }
-    }
-
-    private Camel.FolderInfoFlags get_full_folder_info_flags (Camel.FolderInfo folderinfo) {
-        Camel.FolderInfoFlags full_flags = folderinfo.flags;
-
-        var folder_uri = build_folder_uri (account.service.uid, folderinfo.full_name);
-        var session = Mail.Backend.Session.get_default ();
-        var service_source = session.ref_source (account.service.uid);
-
-        if (service_source != null && service_source.has_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT)) {
-            var mail_account_extension = (E.SourceMailAccount) service_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
-
-            if (mail_account_extension.dup_archive_folder () == folder_uri) {
-                full_flags = full_flags | Camel.FolderInfoFlags.TYPE_ARCHIVE;
-            }
-
-            var identity_uid = mail_account_extension.dup_identity_uid ();
-            var identity_source = session.ref_source (identity_uid);
-
-            if (identity_source != null) {
-                var mail_composition_extension = (E.SourceMailComposition?) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_COMPOSITION);
-                var mail_submission_extension = (E.SourceMailSubmission?) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION);
-
-                if (mail_composition_extension != null && mail_composition_extension.dup_drafts_folder () == folder_uri) {
-                    full_flags = full_flags | Camel.FolderInfoFlags.TYPE_DRAFTS;
-                } else if (mail_submission_extension != null && mail_submission_extension.dup_sent_folder () == folder_uri) {
-                    full_flags = full_flags | Camel.FolderInfoFlags.TYPE_SENT;
-                }
-            }
-        }
-
-        return full_flags;
-    }
-
-    private string build_folder_uri (string service_uid, string folder_name) {
-        var normed_folder_name = folder_name;
-
-        // Skip the leading slash, if present.
-        if (normed_folder_name.has_prefix ("/") ) {
-            normed_folder_name = normed_folder_name.substring (1);
-        }
-
-        var encoded_service_uid = Camel.URL.encode (service_uid, ":;@/");
-        var encoded_normed_folder_name = Camel.URL.encode (normed_folder_name, ":;@?#");
-
-        return "folder://%s/%s".printf (encoded_service_uid, encoded_normed_folder_name);
     }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -69,4 +69,50 @@ public class Mail.Utils {
 
         return null;
     }
+
+    public static Camel.FolderInfoFlags get_full_folder_info_flags (Camel.Service service, Camel.FolderInfo folderinfo) {
+        Camel.FolderInfoFlags full_flags = folderinfo.flags;
+
+        var folder_uri = build_folder_uri (service.uid, folderinfo.full_name);
+        var session = Mail.Backend.Session.get_default ();
+        var service_source = session.ref_source (service.uid);
+
+        if (service_source != null && service_source.has_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT)) {
+            var mail_account_extension = (E.SourceMailAccount) service_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+
+            if (mail_account_extension.dup_archive_folder () == folder_uri) {
+                full_flags = full_flags | Camel.FolderInfoFlags.TYPE_ARCHIVE;
+            }
+
+            var identity_uid = mail_account_extension.dup_identity_uid ();
+            var identity_source = session.ref_source (identity_uid);
+
+            if (identity_source != null) {
+                var mail_composition_extension = (E.SourceMailComposition?) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_COMPOSITION);
+                var mail_submission_extension = (E.SourceMailSubmission?) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION);
+
+                if (mail_composition_extension != null && mail_composition_extension.dup_drafts_folder () == folder_uri) {
+                    full_flags = full_flags | Camel.FolderInfoFlags.TYPE_DRAFTS;
+                } else if (mail_submission_extension != null && mail_submission_extension.dup_sent_folder () == folder_uri) {
+                    full_flags = full_flags | Camel.FolderInfoFlags.TYPE_SENT;
+                }
+            }
+        }
+
+        return full_flags;
+    }
+
+    public static string build_folder_uri (string service_uid, string folder_name) {
+        var normed_folder_name = folder_name;
+
+        // Skip the leading slash, if present.
+        if (normed_folder_name.has_prefix ("/") ) {
+            normed_folder_name = normed_folder_name.substring (1);
+        }
+
+        var encoded_service_uid = Camel.URL.encode (service_uid, ":;@/");
+        var encoded_normed_folder_name = Camel.URL.encode (normed_folder_name, ":;@?#");
+
+        return "folder://%s/%s".printf (encoded_service_uid, encoded_normed_folder_name);
+    }
 }


### PR DESCRIPTION
When we are in the Sent folder, we don't want to show the sender's address in the conversation list because this will always be our own address. Instead, we want to display to whom we've sent the mail.

This PR corrects exactly this behavior.