### PR TITLE
MainWindow: Use multiple headerbars

### DIFF
--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -51,12 +51,14 @@ public class Mail.FoldersListView : Gtk.Grid {
             show_close_button = true
         };
         header_bar.pack_end (compose_button);
+        header_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
         scrolled_window.add (source_list);
 
         orientation = Gtk.Orientation.VERTICAL;
         width_request = 100;
+        get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
         add (header_bar);
         add (scrolled_window);
 

--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -20,8 +20,10 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Mail.FoldersListView : Gtk.ScrolledWindow {
+public class Mail.FoldersListView : Gtk.Grid {
     public signal void folder_selected (Gee.Map<Backend.Account, string?> folder_full_name_per_account);
+
+    public Hdy.HeaderBar header_bar { get; private set; }
 
     private Granite.Widgets.SourceList source_list;
     private Mail.SessionSourceItem session_source_item;
@@ -32,10 +34,32 @@ public class Mail.FoldersListView : Gtk.ScrolledWindow {
     }
 
     construct {
-        width_request = 100;
-
         source_list = new Granite.Widgets.SourceList ();
-        add (source_list);
+
+        var application_instance = (Gtk.Application) GLib.Application.get_default ();
+
+        var compose_button = new Gtk.Button.from_icon_name ("mail-message-new", Gtk.IconSize.LARGE_TOOLBAR) {
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_COMPOSE_MESSAGE,
+            halign = Gtk.Align.START
+        };
+        compose_button.tooltip_markup = Granite.markup_accel_tooltip (
+            application_instance.get_accels_for_action (compose_button.action_name),
+            _("Compose new message")
+        );
+
+        header_bar = new Hdy.HeaderBar () {
+            show_close_button = true
+        };
+        header_bar.pack_end (compose_button);
+
+        var scrolled_window = new Gtk.ScrolledWindow (null, null);
+        scrolled_window.add (source_list);
+
+        orientation = Gtk.Orientation.VERTICAL;
+        width_request = 100;
+        add (header_bar);
+        add (scrolled_window);
+
         var session = Mail.Backend.Session.get_default ();
 
         session_source_item = new Mail.SessionSourceItem (session);

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -19,9 +19,6 @@
 
 public class Mail.HeaderBar : Hdy.HeaderBar {
     public bool can_mark { get; set; }
-    public bool can_search { get; set; }
-    public Gtk.SearchEntry search_entry { get; construct; }
-    private Gtk.Grid spacing_widget;
 
     public HeaderBar () {
         Object (show_close_button: true,
@@ -30,22 +27,6 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
 
     construct {
         var application_instance = (Gtk.Application) GLib.Application.get_default ();
-
-        var compose_button = new Gtk.Button.from_icon_name ("mail-message-new", Gtk.IconSize.LARGE_TOOLBAR) {
-            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_COMPOSE_MESSAGE,
-            halign = Gtk.Align.START
-        };
-        compose_button.tooltip_markup = Granite.markup_accel_tooltip (
-            application_instance.get_accels_for_action (compose_button.action_name),
-            _("Compose new message")
-        );
-
-        spacing_widget = new Gtk.Grid ();
-
-        search_entry = new Gtk.SearchEntry () {
-            placeholder_text = _("Search Mail"),
-            valign = Gtk.Align.CENTER
-        };
 
         var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));
 
@@ -144,9 +125,6 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
             _("Move conversations to Trash")
         );
 
-        pack_start (compose_button);
-        pack_start (spacing_widget);
-        pack_start (search_entry);
         pack_start (reply_button);
         pack_start (reply_all_button);
         pack_start (forward_button);
@@ -157,7 +135,6 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
         pack_end (app_menu);
 
         bind_property ("can-mark", mark_button, "sensitive");
-        bind_property ("can-search", search_entry, "sensitive", BindingFlags.SYNC_CREATE);
 
         var settings = new GLib.Settings ("io.elementary.mail");
         settings.bind ("always-load-remote-images", load_images_menuitem, "active", SettingsBindFlags.DEFAULT);
@@ -169,31 +146,5 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
                 warning ("Failed to open account settings: %s", e.message);
             }
         });
-    }
-
-    public void set_paned_positions (int start_position, int end_position, bool start_changed = true) {
-        // Not sure where these 3px comes from, but it makes the lines line up
-        search_entry.width_request = end_position - start_position + 3;
-        if (start_changed) {
-            int spacing_position;
-            child_get (spacing_widget, "position", out spacing_position, null);
-            var style_context = get_style_context ();
-            // The left padding between the window and the headerbar widget
-            int offset = style_context.get_padding (style_context.get_state ()).left;
-            forall ((widget) => {
-                if (widget == custom_title || widget.get_style_context ().has_class ("right")) {
-                    return;
-                }
-
-                int widget_position;
-                child_get (widget, "position", out widget_position, null);
-                if (widget_position < spacing_position) {
-                    offset += widget.get_allocated_width () + spacing;
-                }
-            });
-
-            offset += spacing;
-            spacing_widget.width_request = start_position - int.min (offset, start_position) - 1;
-        }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -114,6 +114,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         }
 
         headerbar = new HeaderBar ();
+        headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         folders_list_view = new FoldersListView ();
         conversation_list_box = new ConversationListBox ();
@@ -149,6 +150,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         };
 
         var search_header = new Hdy.HeaderBar ();
+        search_header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         search_header.set_custom_title (search_entry);
 
         var conversation_list_scrolled = new Gtk.ScrolledWindow (null, null) {
@@ -229,6 +231,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         view_overlay.add (message_list_scrolled);
 
         var message_list_container = new Gtk.Grid ();
+        message_list_container.get_style_context ().add_class ("deck");
         message_list_container.attach (headerbar, 0, 0);
         message_list_container.attach (view_overlay, 0, 1);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -215,6 +215,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         conversation_list_grid.attach (search_header, 0, 0);
         conversation_list_grid.attach (conversation_list_scrolled, 0, 1);
         conversation_list_grid.attach (conversation_action_bar, 0, 2);
+        conversation_list_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
 
         message_list_scrolled = new Gtk.ScrolledWindow (null, null);
         message_list_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -231,7 +232,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         view_overlay.add (message_list_scrolled);
 
         var message_list_container = new Gtk.Grid ();
-        message_list_container.get_style_context ().add_class ("deck");
+        message_list_container.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
         message_list_container.attach (headerbar, 0, 0);
         message_list_container.attach (view_overlay, 0, 1);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,9 +20,9 @@
 
 public class Mail.MainWindow : Hdy.ApplicationWindow {
     private HeaderBar headerbar;
+    private Gtk.SearchEntry search_entry;
     private Gtk.Paned paned_end;
     private Gtk.Paned paned_start;
-    private Gtk.Grid container_grid;
 
     private FoldersListView folders_list_view;
     private Gtk.Overlay view_overlay;
@@ -142,6 +142,15 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         message_list_box.bind_property ("can-move-thread", get_action (ACTION_ARCHIVE), "enabled", BindingFlags.SYNC_CREATE);
         message_list_box.bind_property ("can-move-thread", headerbar, "can-mark", BindingFlags.SYNC_CREATE);
 
+        search_entry = new Gtk.SearchEntry () {
+            hexpand = true,
+            placeholder_text = _("Search Mail"),
+            valign = Gtk.Align.CENTER
+        };
+
+        var search_header = new Hdy.HeaderBar ();
+        search_header.set_custom_title (search_entry);
+
         var conversation_list_scrolled = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
             width_request = 158,
@@ -201,8 +210,9 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         conversation_action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var conversation_list_grid = new Gtk.Grid ();
-        conversation_list_grid.attach (conversation_list_scrolled, 0, 0);
-        conversation_list_grid.attach (conversation_action_bar, 0, 1);
+        conversation_list_grid.attach (search_header, 0, 0);
+        conversation_list_grid.attach (conversation_list_scrolled, 0, 1);
+        conversation_list_grid.attach (conversation_action_bar, 0, 2);
 
         message_list_scrolled = new Gtk.ScrolledWindow (null, null);
         message_list_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -213,10 +223,18 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             ((Gtk.Container) scrolled_child).set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
         }
 
-        view_overlay = new Gtk.Overlay ();
+        view_overlay = new Gtk.Overlay () {
+            expand = true
+        };
         view_overlay.add (message_list_scrolled);
+
+        var message_list_container = new Gtk.Grid ();
+        message_list_container.attach (headerbar, 0, 0);
+        message_list_container.attach (view_overlay, 0, 1);
+
         var message_overlay = new Granite.Widgets.OverlayBar (view_overlay);
         message_overlay.no_show_all = true;
+
         message_list_box.hovering_over_link.connect ((label, url) => {
             var hover_url = url != null ? Soup.URI.decode (url) : null;
 
@@ -234,7 +252,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         paned_end = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_end.pack1 (paned_start, false, false);
-        paned_end.pack2 (view_overlay, true, true);
+        paned_end.pack2 (message_list_container, true, true);
 
         var welcome_view = new Mail.WelcomeView ();
 
@@ -243,11 +261,17 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         placeholder_stack.add_named (paned_end, "mail");
         placeholder_stack.add_named (welcome_view, "welcome");
 
-        container_grid = new Gtk.Grid ();
-        container_grid.attach (headerbar, 0, 0);
-        container_grid.attach (placeholder_stack, 0, 1);
+        add (placeholder_stack);
 
-        add (container_grid);
+        var header_group = new Hdy.HeaderGroup ();
+        header_group.add_header_bar (folders_list_view.header_bar);
+        header_group.add_header_bar (search_header);
+        header_group.add_header_bar (headerbar);
+
+        var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
+        size_group.add_widget (folders_list_view.header_bar);
+        size_group.add_widget (search_header);
+        size_group.add_widget (headerbar);
 
         var settings = new GLib.Settings ("io.elementary.mail");
         settings.bind ("paned-start-position", paned_start, "position", SettingsBindFlags.DEFAULT);
@@ -270,24 +294,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             }
         });
 
-        headerbar.bind_property ("can-search", filter_button, "sensitive", BindingFlags.SYNC_CREATE);
+        search_entry.bind_property ("sensitive", filter_button, "sensitive", BindingFlags.SYNC_CREATE);
 
         hide_read_switch.notify["active"].connect (on_filter_button_changed);
         hide_unstarred_switch.notify["active"].connect (on_filter_button_changed);
 
-        headerbar.size_allocate.connect (() => {
-            headerbar.set_paned_positions (paned_start.position, paned_end.position);
-        });
-
-        paned_end.notify["position"].connect (() => {
-            headerbar.set_paned_positions (paned_start.position, paned_end.position, false);
-        });
-
-        paned_start.notify["position"].connect (() => {
-            headerbar.set_paned_positions (paned_start.position, paned_end.position);
-        });
-
-        headerbar.search_entry.search_changed.connect (() => {
+        search_entry.search_changed.connect (() => {
             if (search_changed_debounce_timeout_id != 0) {
                 GLib.Source.remove (search_changed_debounce_timeout_id);
             }
@@ -295,7 +307,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             search_changed_debounce_timeout_id = GLib.Timeout.add (800, () => {
                 search_changed_debounce_timeout_id = 0;
 
-                var search_term = headerbar.search_entry.text.strip ();
+                var search_term = search_entry.text.strip ();
                 conversation_list_box.search.begin (search_term == "" ? null : search_term);
 
                 return GLib.Source.REMOVE;
@@ -306,14 +318,14 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         session.account_added.connect (() => {
             placeholder_stack.visible_child = paned_end;
             get_action (ACTION_COMPOSE_MESSAGE).set_enabled (true);
-            headerbar.can_search = true;
+            search_entry.sensitive = true;
         });
 
         session.account_removed.connect (() => {
             var accounts_left = session.get_accounts ();
             if (accounts_left.size == 0) {
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
-                headerbar.can_search = false;
+                search_entry.sensitive = false;
             }
         });
 
@@ -334,7 +346,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             style_context.remove_class (Granite.STYLE_CLASS_ACCENT);
         }
 
-        conversation_list_box.search.begin (headerbar.search_entry.text, hide_read_switch.active, hide_unstarred_switch.active);
+        conversation_list_box.search.begin (search_entry.text, hide_read_switch.active, hide_unstarred_switch.active);
     }
 
     private void on_compose_message () {

--- a/src/MessageList/MessageListBox.vala
+++ b/src/MessageList/MessageListBox.vala
@@ -36,7 +36,7 @@ public class Mail.MessageListBox : Gtk.ListBox {
         placeholder_style_context.add_class (Granite.STYLE_CLASS_H2_LABEL);
         placeholder_style_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        get_style_context ().add_class ("deck");
+        get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
         set_placeholder (placeholder);
         set_sort_func (message_sort_function);
     }

--- a/src/WelcomeView.vala
+++ b/src/WelcomeView.vala
@@ -18,10 +18,12 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Mail.WelcomeView : Gtk.Grid {
+public class Mail.WelcomeView : Gtk.Box {
     construct {
-        halign = valign = Gtk.Align.CENTER;
-        orientation = Gtk.Orientation.VERTICAL;
+        var headerbar = new Hdy.HeaderBar () {
+            show_close_button = true
+        };
+        headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var welcome_icon = new Gtk.Image ();
         welcome_icon.icon_name = "io.elementary.mail";
@@ -37,36 +39,51 @@ public class Mail.WelcomeView : Gtk.Grid {
         welcome_overlay.add (welcome_icon);
         welcome_overlay.add_overlay (welcome_badge);
 
-        var welcome_title = new Gtk.Label (_("Connect an Account"));
-        welcome_title.wrap = true;
-        welcome_title.max_width_chars = 70;
+        var welcome_title = new Gtk.Label (_("Connect an Account")) {
+            max_width_chars = 70,
+            wrap = true,
+            xalign = 0
+        };
         welcome_title.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
 
-        var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings."));
-        welcome_description.wrap = true;
-        welcome_description.max_width_chars = 70;
+        var welcome_description = new Gtk.Label (_("Mail uses email accounts configured in System Settings.")) {
+            max_width_chars = 70,
+            wrap = true,
+            xalign = 0
+        };
         welcome_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
-        var welcome_button = new Gtk.Button.with_label (_("Online Accounts…"));
-        weak Gtk.StyleContext welcome_button_style_context = welcome_button.get_style_context ();
-        welcome_button.halign = Gtk.Align.CENTER;
-        welcome_button.margin_top = 24;
-        welcome_button_style_context.add_class (Granite.STYLE_CLASS_H3_LABEL);
-        welcome_button_style_context.add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        var welcome_button = new Gtk.Button.with_label (_("Online Accounts…")) {
+            margin_top = 24
+        };
+        welcome_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
-        add (welcome_overlay);
-        add (welcome_title);
-        add (welcome_description);
-        add (welcome_button);
+        var grid = new Gtk.Grid () {
+            column_spacing = 12,
+            halign = valign = Gtk.Align.CENTER,
+            expand = true
+        };
+        grid.attach (welcome_overlay, 0, 0, 1, 2);
+        grid.attach (welcome_title, 1, 0);
+        grid.attach (welcome_description, 1, 1);
+        grid.attach (welcome_button, 1, 2);
+
+        var main_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        main_box.add (headerbar);
+        main_box.add (grid);
+
+        var window_handle = new Hdy.WindowHandle ();
+        window_handle.add (main_box);
+
+        add (window_handle);
+        show_all ();
 
         welcome_button.clicked.connect (() => {
             try {
-                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+                Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), "settings://accounts/online", Gdk.CURRENT_TIME);
             } catch (Error e) {
                 critical (e.message);
             }
         });
-
-        show_all ();
     }
 }


### PR DESCRIPTION
Follow up to #462

Gets rid of some resizing voodoo.

![Screenshot from 2022-04-06 16 07 04](https://user-images.githubusercontent.com/7277719/162087657-0724805d-a94f-48cf-8039-d08bebb2c83a.png)

Clean up the welcome screen:
* Layout more similar to Granite 7's Placeholder
* Use Gtk.Show_uri_on_window for better window management stuff
* Easier window moving with window handle

![Screenshot from 2022-05-14 10 28 24](https://user-images.githubusercontent.com/7277719/168442469-609c0cf7-d778-4c25-b987-53cd873b2de3.png)
