### PR TITLE
FoldersListView: move settings here

### DIFF
--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -56,11 +56,45 @@ public class Mail.FoldersListView : Gtk.Grid {
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
         scrolled_window.add (source_list);
 
+        var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));
+
+        var account_settings_menuitem = new Gtk.ModelButton ();
+        account_settings_menuitem.text = _("Account Settings…");
+
+        var app_menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            margin_bottom = 3,
+            margin_top = 3
+        };
+
+        var app_menu_grid = new Gtk.Grid () {
+            margin_bottom = 3,
+            margin_top = 3,
+            orientation = Gtk.Orientation.VERTICAL
+        };
+        app_menu_grid.add (load_images_menuitem);
+        app_menu_grid.add (app_menu_separator);
+        app_menu_grid.add (account_settings_menuitem);
+        app_menu_grid.show_all ();
+
+        var app_menu_popover = new Gtk.Popover (null);
+        app_menu_popover.add (app_menu_grid);
+
+        var app_menu = new Gtk.MenuButton () {
+            image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+            popover = app_menu_popover,
+            tooltip_text = _("Menu")
+        };
+
+        var action_bar = new Gtk.ActionBar ();
+        action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        action_bar.pack_end (app_menu);
+
         orientation = Gtk.Orientation.VERTICAL;
         width_request = 100;
         get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
         add (header_bar);
         add (scrolled_window);
+        add (action_bar);
 
         var session = Mail.Backend.Session.get_default ();
 
@@ -91,6 +125,17 @@ public class Mail.FoldersListView : Gtk.Grid {
                 folder_selected (grouped_folder_item.get_folder_full_name_per_account ());
 
                 settings.set ("selected-folder", "(ss)", "GROUPED", grouped_folder_item.name);
+            }
+        });
+
+        var settings = new GLib.Settings ("io.elementary.mail");
+        settings.bind ("always-load-remote-images", load_images_menuitem, "active", SettingsBindFlags.DEFAULT);
+
+        account_settings_menuitem.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+            } catch (Error e) {
+                warning ("Failed to open account settings: %s", e.message);
             }
         });
     }

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -28,35 +28,6 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
     construct {
         var application_instance = (Gtk.Application) GLib.Application.get_default ();
 
-        var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));
-
-        var account_settings_menuitem = new Gtk.ModelButton ();
-        account_settings_menuitem.text = _("Account Settings…");
-
-        var app_menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
-            margin_bottom = 3,
-            margin_top = 3
-        };
-
-        var app_menu_grid = new Gtk.Grid () {
-            margin_bottom = 3,
-            margin_top = 3,
-            orientation = Gtk.Orientation.VERTICAL
-        };
-        app_menu_grid.add (load_images_menuitem);
-        app_menu_grid.add (app_menu_separator);
-        app_menu_grid.add (account_settings_menuitem);
-        app_menu_grid.show_all ();
-
-        var app_menu_popover = new Gtk.Popover (null);
-        app_menu_popover.add (app_menu_grid);
-
-        var app_menu = new Gtk.MenuButton () {
-            image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),
-            popover = app_menu_popover,
-            tooltip_text = _("Menu")
-        };
-
         var reply_button = new Gtk.Button.from_icon_name ("mail-reply-sender", Gtk.IconSize.LARGE_TOOLBAR);
         reply_button.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_REPLY;
         reply_button.tooltip_markup = Granite.markup_accel_tooltip (
@@ -128,23 +99,10 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
         pack_start (reply_button);
         pack_start (reply_all_button);
         pack_start (forward_button);
-        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        pack_start (mark_button);
-        pack_start (archive_button);
-        pack_start (trash_button);
-        pack_end (app_menu);
+        pack_end (trash_button);
+        pack_end (archive_button);
+        pack_end (mark_button);
 
         bind_property ("can-mark", mark_button, "sensitive");
-
-        var settings = new GLib.Settings ("io.elementary.mail");
-        settings.bind ("always-load-remote-images", load_images_menuitem, "active", SettingsBindFlags.DEFAULT);
-
-        account_settings_menuitem.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
-            } catch (Error e) {
-                warning ("Failed to open account settings: %s", e.message);
-            }
-        });
     }
 }


### PR DESCRIPTION
![Screenshot from 2022-05-23 19 40 28](https://user-images.githubusercontent.com/7277719/169937750-a9929261-46c6-4cbd-981a-846fc3f63e31.png)

In line with making sure actions affect the panes they appear in, account settings belongs to the pane that shows accounts.

While we're here push our conversation actions to the start and end of that headerbar instead of using a separator, now that there's nothing on the right side. Conveniently makes space for https://github.com/elementary/mail/pull/783