### PR TITLE
MainWindow: Spelling: ellipsis

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -174,7 +174,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             active = true,
             halign = Gtk.Align.CENTER,
             valign = Gtk.Align.CENTER,
-            tooltip_text = _("Fetching new messages")
+            tooltip_text = _("Fetching new messages…")
         };
 
         refresh_stack = new Gtk.Stack () {


### PR DESCRIPTION
Consistent with other strings if it is a concurrent action.
Should be something other than the name if it is just the tooltip.