### PR TITLE
build: fix documentation build

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -11,6 +11,7 @@ basic_command = [
     '--pkg', 'webkit2gtk-4.0',
     '--pkg', 'libedataserverui-1.2',
     '--pkg', 'libedataserver-1.2',
+    '--pkg', 'libhandy-1',
     '--pkg', 'camel-1.2',
     '--pkg', 'gee-0.8', 
     '--pkg', 'granite',
@@ -30,7 +31,7 @@ all_doc_target = custom_target(
         '@INPUT@'
     ],
     build_by_default: true,
-    input: vala_files,
+    input: [vala_files, config_file],
     output: 'full'
 )
 


### PR DESCRIPTION
As mentioned in https://github.com/elementary/mail/pull/794#discussion_r930079796, I guess I will split out the change as a new PR since looks like squash merge is more commonly used here...

Without the change documentation build fails with

```
ComposerWindow.vala:21.36-21.38: error: The symbol `Hdy' could not be found
FoldersListView.vala:26.12-26.14: error: The symbol `Hdy' could not be found
```

```
Application.vala:43.30-43.44: error: The name `GETTEXT_PACKAGE' does not exist in the context of `Mail.Application'
Application.vala:43.47-43.55: error: The name `LOCALEDIR' does not exist in the context of `Mail.Application'
Application.vala:44.39-44.53: error: The name `GETTEXT_PACKAGE' does not exist in the context of `Mail.Application'
Application.vala:45.26-45.40: error: The name `GETTEXT_PACKAGE' does not exist in the context of `Mail.Application'
```

