### PR TITLE
Docs: Add curiously omitted dependency on meson to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You'll need the following dependencies:
 * libgranite-dev >= 6.0.0
 * libhandy-1-dev >= 1.1.90
 * libwebkit2gtk-4.0-dev
+* meson
 * valac
 
 Run `meson build` to configure the build environment and then change to the build directory and run `ninja` to build


### PR DESCRIPTION
Every other elementary repo correctly lists `meson` as one of the dependencies to build its application. For some reason this is currently missing from the dependency list here.

This PR includes the dependency on meson as done in every other repo.