### PR TITLE
MessageListItem: avoid crashing on empty Mime

### DIFF
--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -484,6 +484,10 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
     private async void open_message (Camel.MimeMessage message) {
         yield parse_mime_content (message.content);
+        if (message_content == null) {
+            return;
+        }
+
         if (message_is_html) {
             web_view.load_html (message_content);
         } else {


### PR DESCRIPTION
I have been able to trigger this by changing the selected folder while it is loading.