### PR TITLE
Replace unnecessary grids with boxes

### DIFF
--- a/src/Composer/ComposerWidget.vala
+++ b/src/Composer/ComposerWidget.vala
@@ -906,16 +906,15 @@ public class Mail.ComposerWidget : Gtk.Box {
             remove_button_context.add_class (Gtk.STYLE_CLASS_FLAT);
             remove_button_context.add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-            var grid = new Gtk.Grid () {
-                column_spacing = 3,
+            var box = new Gtk.Box (HORIZONTAL, 3) {
                 margin = 3
             };
-            grid.add (image);
-            grid.add (name_label);
-            grid.add (size_label);
-            grid.add (remove_button);
+            box.add (image);
+            box.add (name_label);
+            box.add (size_label);
+            box.add (remove_button);
 
-            add (grid);
+            add (box);
 
             remove_button.clicked.connect (() => {
                 destroy ();

--- a/src/Composer/ComposerWindow.vala
+++ b/src/Composer/ComposerWindow.vala
@@ -58,16 +58,15 @@ public class Mail.ComposerWindow : Hdy.ApplicationWindow {
             titlebar.title = title = subject;
         });
 
-        var content_grid = new Gtk.Grid ();
-        content_grid.orientation = Gtk.Orientation.VERTICAL;
-        content_grid.add (titlebar);
-        content_grid.add (composer_widget);
+        var content_box = new Gtk.Box (VERTICAL, 0);
+        content_box.add (titlebar);
+        content_box.add (composer_widget);
 
         height_request = 600;
         width_request = 680;
         title = _("New Message");
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
 
-        add (content_grid);
+        add (content_box);
     }
 }

--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -36,18 +36,17 @@ public class Mail.HeaderBar : Hdy.HeaderBar {
             margin_top = 3
         };
 
-        var app_menu_grid = new Gtk.Grid () {
+        var app_menu_box = new Gtk.Box (VERTICAL, 0) {
             margin_bottom = 3,
-            margin_top = 3,
-            orientation = Gtk.Orientation.VERTICAL
+            margin_top = 3
         };
-        app_menu_grid.add (load_images_menuitem);
-        app_menu_grid.add (app_menu_separator);
-        app_menu_grid.add (account_settings_menuitem);
-        app_menu_grid.show_all ();
+        app_menu_box.add (load_images_menuitem);
+        app_menu_box.add (app_menu_separator);
+        app_menu_box.add (account_settings_menuitem);
+        app_menu_box.show_all ();
 
         var app_menu_popover = new Gtk.Popover (null);
-        app_menu_popover.add (app_menu_grid);
+        app_menu_popover.add (app_menu_box);
 
         var app_menu = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -184,17 +184,16 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         hide_unstarred_switch = new Granite.SwitchModelButton (_("Hide unstarred conversations"));
 
-        var filter_menu_popover_grid = new Gtk.Grid () {
+        var filter_menu_popover_box = new Gtk.Box (VERTICAL, 0) {
             margin_bottom = 3,
-            margin_top = 3,
-            orientation = Gtk.Orientation.VERTICAL
+            margin_top = 3
         };
-        filter_menu_popover_grid.add (hide_read_switch);
-        filter_menu_popover_grid.add (hide_unstarred_switch);
-        filter_menu_popover_grid.show_all ();
+        filter_menu_popover_box.add (hide_read_switch);
+        filter_menu_popover_box.add (hide_unstarred_switch);
+        filter_menu_popover_box.show_all ();
 
         var filter_popover = new Gtk.Popover (null);
-        filter_popover.add (filter_menu_popover_grid);
+        filter_popover.add (filter_menu_popover_box);
 
         filter_button = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("mail-filter-symbolic", Gtk.IconSize.SMALL_TOOLBAR),

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -266,21 +266,19 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             loaded = true;
         });
 
-        var secondary_grid = new Gtk.Grid ();
-        secondary_grid.orientation = Gtk.Orientation.VERTICAL;
-        secondary_grid.add (separator);
-        secondary_grid.add (blocked_images_infobar);
-        secondary_grid.add (web_view);
+        var secondary_box = new Gtk.Box (VERTICAL, 0);
+        secondary_box.add (separator);
+        secondary_box.add (blocked_images_infobar);
+        secondary_box.add (web_view);
 
         secondary_revealer = new Gtk.Revealer ();
         secondary_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_UP;
-        secondary_revealer.add (secondary_grid);
+        secondary_revealer.add (secondary_box);
 
-        var base_grid = new Gtk.Grid ();
-        base_grid.expand = true;
-        base_grid.orientation = Gtk.Orientation.VERTICAL;
-        base_grid.add (header_event_box);
-        base_grid.add (secondary_revealer);
+        var base_box = new Gtk.Box (VERTICAL, 0);
+        base_box.expand = true;
+        base_box.add (header_event_box);
+        base_box.add (secondary_revealer);
 
         if (Camel.MessageFlags.ATTACHMENTS in (int) message_info.flags) {
             var attachment_icon = new Gtk.Image.from_icon_name ("mail-attachment-symbolic", Gtk.IconSize.MENU);
@@ -289,10 +287,10 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             action_grid.attach (attachment_icon, 1, 0);
 
             attachment_bar = new AttachmentBar (loading_cancellable);
-            secondary_grid.add (attachment_bar);
+            secondary_box.add (attachment_bar);
         }
 
-        add (base_grid);
+        add (base_box);
         expanded = false;
         show_all ();
 


### PR DESCRIPTION
This is being done in preparation for a GTK4 port, because a convenience method to add items to grids which have only a single column or row was removed in GTK4. However those grids can be easily replaced with boxes.