### PR TITLE
Improve startup time and proper handling of online/offline states

### DIFF
--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -42,7 +42,7 @@ public class Mail.Backend.Session : Camel.Session {
         Camel.init (E.get_user_data_dir (), false);
         accounts = new Gee.LinkedList<Account> ();
         set_network_monitor (E.NetworkMonitor.get_default ());
-        set_online (true);
+        set_online (false);
         user_alert.connect ((service, type, message) => { warning (message); });
     }
 

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -47,10 +47,6 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
         offlinestore.folder_deleted.connect (folder_deleted);
         offlinestore.folder_info_stale.connect (reload_folders);
         offlinestore.folder_renamed.connect (folder_renamed);
-        unowned GLib.NetworkMonitor network_monitor = GLib.NetworkMonitor.get_default ();
-        network_monitor.network_changed.connect (() =>{
-            connect_to_account.begin ();
-        });
     }
 
     ~AccountSourceItem () {
@@ -63,34 +59,6 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
             if (folderinfo != null) {
                 show_info (folderinfo, this);
             }
-        } catch (Error e) {
-            critical (e.message);
-        }
-
-        connect_to_account.begin ();
-    }
-
-    private async void connect_to_account () {
-        var session = Mail.Backend.Session.get_default ();
-
-        unowned GLib.NetworkMonitor network_monitor = GLib.NetworkMonitor.get_default ();
-        if (!network_monitor.network_available) {
-            try {
-                yield offlinestore.set_online (false, GLib.Priority.DEFAULT, connect_cancellable);
-            } catch (Error e) {
-                critical (e.message);
-            }
-            session.set_online (false);
-            return;
-        }
-
-        session.set_online (true);
-
-        try {
-            yield offlinestore.set_online (true, GLib.Priority.DEFAULT, connect_cancellable);
-            yield offlinestore.connect (GLib.Priority.DEFAULT, connect_cancellable);
-
-            yield offlinestore.synchronize (false, GLib.Priority.DEFAULT, connect_cancellable);
         } catch (Error e) {
             critical (e.message);
         }

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -77,22 +77,16 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
         if (!network_monitor.network_available) {
             try {
                 yield offlinestore.set_online (false, GLib.Priority.DEFAULT, connect_cancellable);
-
-                if (session.online) {
-                    session.set_online (false);
-                }
-                return;
+                session.set_online (false);
             } catch (Error e) {
                 critical (e.message);
-                return;
             }
+            return;
         }
 
-        try {
-            if (!session.online) {
-                session.set_online (true);
-            }
+        session.set_online (true);
 
+        try {
             yield offlinestore.set_online (true, GLib.Priority.DEFAULT, connect_cancellable);
             yield offlinestore.connect (GLib.Priority.DEFAULT, connect_cancellable);
 

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -77,10 +77,10 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
         if (!network_monitor.network_available) {
             try {
                 yield offlinestore.set_online (false, GLib.Priority.DEFAULT, connect_cancellable);
-                session.set_online (false);
             } catch (Error e) {
                 critical (e.message);
             }
+            session.set_online (false);
             return;
         }
 

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -72,6 +72,7 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
 
     private async void connect_to_account () {
         var session = Mail.Backend.Session.get_default ();
+
         unowned GLib.NetworkMonitor network_monitor = GLib.NetworkMonitor.get_default ();
         if (!network_monitor.network_available) {
             try {
@@ -88,7 +89,7 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem {
         }
 
         try {
-            if(!session.online) {
+            if (!session.online) {
                 session.set_online (true);
             }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -286,8 +286,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         settings.bind ("paned-start-position", paned_start, "position", SettingsBindFlags.DEFAULT);
         settings.bind ("paned-end-position", paned_end, "position", SettingsBindFlags.DEFAULT);
 
-        destroy.connect (() => destroy ());
-
         folders_list_view.folder_selected.connect ((folder_full_name_per_account) => {
             conversation_list_box.load_folder.begin (folder_full_name_per_account);
         });
@@ -325,7 +323,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
 
-        session.account_removed.connect (() => {
+        var account_removed_handler = session.account_removed.connect (() => {
             var accounts_left = session.get_accounts ();
             if (accounts_left.size == 0) {
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
@@ -333,7 +331,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             }
         });
 
-        session.notify["online"].connect (() => {
+        var connection_handler = session.notify["online"].connect (() => {
             if (session.online) {
                 connection_info_bar.set_revealed (false);
             } else {
@@ -354,6 +352,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
             is_session_started = true;
             session_started ();
+        });
+
+        destroy.connect (() =>  {
+            session.disconnect (account_removed_handler);
+            session.disconnect (connection_handler);
+            destroy ();
         });
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -149,6 +149,11 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         search_header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         search_header.set_custom_title (search_entry);
 
+        var connection_info_bar = new Gtk.InfoBar () {
+            message_type = WARNING
+        };
+        connection_info_bar.get_content_area ().add (new Gtk.Label (_("You're offline")));
+
         var conversation_list_scrolled = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
             width_request = 158,
@@ -208,8 +213,9 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         var conversation_list_grid = new Gtk.Grid ();
         conversation_list_grid.attach (search_header, 0, 0);
-        conversation_list_grid.attach (conversation_list_scrolled, 0, 1);
-        conversation_list_grid.attach (conversation_action_bar, 0, 2);
+        conversation_list_grid.attach (connection_info_bar, 0, 1);
+        conversation_list_grid.attach (conversation_list_scrolled, 0, 2);
+        conversation_list_grid.attach (conversation_action_bar, 0, 3);
         conversation_list_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
 
         message_list_scrolled = new Gtk.ScrolledWindow (null, null);
@@ -324,6 +330,14 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             if (accounts_left.size == 0) {
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
                 search_entry.sensitive = false;
+            }
+        });
+
+        session.notify["online"].connect (() => {
+            if (session.online) {
+                connection_info_bar.set_revealed (false);
+            } else {
+                connection_info_bar.set_revealed (true);
             }
         });
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -344,6 +344,8 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         session.start.begin ((obj, res) => {
             session.start.end (res);
 
+            connection_info_bar.revealed = !session.online;
+
             if (session.get_accounts ().size > 0) {
                 placeholder_stack.visible_child = paned_end;
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (true);

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -327,7 +327,9 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         expanded = false;
         show_all ();
 
-        avatar.set_loadable_icon (new GravatarIcon (parsed_address, get_style_context ().get_scale ()));
+        if (GLib.NetworkMonitor.get_default ().network_available) {
+            avatar.set_loadable_icon (new GravatarIcon (parsed_address, get_style_context ().get_scale ()));
+        }
 
         /* Override default handler to stop event propagation. Otherwise clicking the menu will
            expand or collapse the MessageListItem. */


### PR DESCRIPTION
Reduce time for first time startup, by first loading cached mails and then connecting to the serverside account. 
Also add proper handling of offline/online states and a banner telling the user when offline.

![Screenshot from 2023-04-05 16-13-54](https://user-images.githubusercontent.com/106322251/230112434-29d48c65-c2c6-493e-ad8f-781c2ea3eaab.png)

Also fixes an issue that caused mail often to freeze when selecting a message after switching off the internet connection while the app was running.
Also fixes an issue that caused mail to sometimes not load folders when offline.

To-Do:
InboxMonitor

Regarding the Banner: The location and style make sense to me, but I am open to suggestions
