### PR TITLE
MainWindow: don't allow pane to shrink past contents

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -234,7 +234,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         paned_end = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_end.pack1 (paned_start, false, false);
-        paned_end.pack2 (view_overlay, true, true);
+        paned_end.pack2 (view_overlay, true, false);
 
         var welcome_view = new Mail.WelcomeView ();
 


### PR DESCRIPTION
Fixes a small issue where you could resize this pane such that controls and contents got cut off