### PR TITLE
Derive MessageListBox from Gtk.Box in preparation for GTK4

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -10,7 +10,7 @@ src/Backend/ContactManager.vala
 src/Composer/ComposerWidget.vala
 src/Composer/ComposerWindow.vala
 src/Composer/InlineComposer.vala
-src/ConversationList/ConversationListBox.vala
+src/ConversationList/ConversationList.vala
 src/ConversationList/ConversationListItem.vala
 src/Dialogs/InsertLinkDialog.vala
 src/FoldersView/AccountSourceItem.vala

--- a/src/ConversationList/ConversationList.vala
+++ b/src/ConversationList/ConversationList.vala
@@ -20,7 +20,7 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Mail.ConversationListBox : Gtk.Box {
+public class Mail.ConversationList : Gtk.Box {
     public signal void conversation_selected (Camel.FolderThreadNode? node);
     public signal void conversation_focused (Camel.FolderThreadNode? node);
 

--- a/src/ConversationList/ConversationList.vala
+++ b/src/ConversationList/ConversationList.vala
@@ -49,9 +49,6 @@ public class Mail.ConversationList : Gtk.Box {
         orientation = VERTICAL;
         get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
 
-        list_box = new VirtualizingListBox () {
-            activate_on_single_click = true
-        };
         conversations = new Gee.HashMap<string, ConversationItemModel> ();
         folders = new Gee.HashMap<string, Camel.Folder> ();
         folder_info_flags = new Gee.HashMap<string, Camel.FolderInfoFlags> ();
@@ -60,9 +57,12 @@ public class Mail.ConversationList : Gtk.Box {
         list_store.set_sort_func (thread_sort_function);
         list_store.set_filter_func (filter_function);
 
-        list_box.model = list_store;
         move_handler = new MoveHandler ();
 
+        list_box = new VirtualizingListBox () {
+            activate_on_single_click = true,
+            model = list_store
+        };
         list_box.factory_func = (item, old_widget) => {
             ConversationListItem? row = null;
             if (old_widget != null) {

--- a/src/ConversationList/ConversationListBox.vala
+++ b/src/ConversationList/ConversationListBox.vala
@@ -82,9 +82,10 @@ public class Mail.ConversationListBox : Gtk.Box {
             valign = Gtk.Align.CENTER
         };
 
-        search_header = new Hdy.HeaderBar ();
+        search_header = new Hdy.HeaderBar () {
+            custom_title = search_entry
+        };
         search_header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        search_header.set_custom_title (search_entry);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
@@ -129,8 +130,9 @@ public class Mail.ConversationListBox : Gtk.Box {
         filter_menu_popover_box.add (hide_unstarred_switch);
         filter_menu_popover_box.show_all ();
 
-        var filter_popover = new Gtk.Popover (null);
-        filter_popover.add (filter_menu_popover_box);
+        var filter_popover = new Gtk.Popover (null) {
+            child = filter_menu_popover_box
+        };
 
         filter_button = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("mail-filter-symbolic", Gtk.IconSize.SMALL_TOOLBAR),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -24,7 +24,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
     private FoldersListView folders_list_view;
     private Gtk.Overlay view_overlay;
-    private ConversationListBox conversation_list_box;
+    private ConversationList conversation_list;
     private MessageList message_list;
 
     private uint configure_id;
@@ -104,11 +104,11 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         }
 
         folders_list_view = new FoldersListView ();
-        conversation_list_box = new ConversationListBox ();
+        conversation_list = new ConversationList ();
 
         // Disable delete accelerators when the conversation list box loses keyboard focus,
         // restore them when it returns
-        conversation_list_box.set_focus_child.connect ((widget) => {
+        conversation_list.set_focus_child.connect ((widget) => {
             if (widget == null) {
                 ((Gtk.Application) GLib.Application.get_default ()).set_accels_for_action (
                     ACTION_PREFIX + ACTION_MOVE_TO_TRASH,
@@ -149,7 +149,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         paned_start = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_start.pack1 (folders_list_view, false, false);
-        paned_start.pack2 (conversation_list_box, true, false);
+        paned_start.pack2 (conversation_list, true, false);
 
         paned_end = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_end.pack1 (paned_start, false, false);
@@ -166,12 +166,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         var header_group = new Hdy.HeaderGroup ();
         header_group.add_header_bar (folders_list_view.header_bar);
-        header_group.add_header_bar (conversation_list_box.search_header);
+        header_group.add_header_bar (conversation_list.search_header);
         header_group.add_header_bar (message_list.headerbar);
 
         var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
         size_group.add_widget (folders_list_view.header_bar);
-        size_group.add_widget (conversation_list_box.search_header);
+        size_group.add_widget (conversation_list.search_header);
         size_group.add_widget (message_list.headerbar);
 
         var settings = new GLib.Settings ("io.elementary.mail");
@@ -180,9 +180,9 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         destroy.connect (() => destroy ());
 
-        folders_list_view.folder_selected.connect (conversation_list_box.load_folder);
+        folders_list_view.folder_selected.connect (conversation_list.load_folder);
 
-        conversation_list_box.conversation_selected.connect (message_list.set_conversation);
+        conversation_list.conversation_selected.connect (message_list.set_conversation);
 
         unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
 
@@ -211,23 +211,23 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     private void on_refresh () {
-        conversation_list_box.refresh_folder.begin ();
+        conversation_list.refresh_folder.begin ();
     }
 
     private void on_mark_read () {
-        conversation_list_box.mark_read_selected_messages ();
+        conversation_list.mark_read_selected_messages ();
     }
 
     private void on_mark_star () {
-        conversation_list_box.mark_star_selected_messages ();
+        conversation_list.mark_star_selected_messages ();
     }
 
     private void on_mark_unread () {
-        conversation_list_box.mark_unread_selected_messages ();
+        conversation_list.mark_unread_selected_messages ();
     }
 
     private void on_mark_unstar () {
-        conversation_list_box.mark_unstar_selected_messages ();
+        conversation_list.mark_unstar_selected_messages ();
     }
 
     private void on_reply () {
@@ -246,11 +246,11 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     private void on_archive () {
-        conversation_list_box.archive_selected_messages.begin ();
+        conversation_list.archive_selected_messages.begin ();
     }
 
     private void on_move_to_trash () {
-        var result = conversation_list_box.trash_selected_messages ();
+        var result = conversation_list.trash_selected_messages ();
         if (result > 0) {
             send_move_toast (ngettext ("Message Deleted", "Messages Deleted", result));
         }
@@ -268,12 +268,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         toast.show_all ();
 
         toast.default_action.connect (() => {
-            conversation_list_box.undo_move ();
+            conversation_list.undo_move ();
         });
 
         toast.notify["child-revealed"].connect (() => {
             if (!toast.child_revealed) {
-                conversation_list_box.undo_expired ();
+                conversation_list.undo_expired ();
             }
         });
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -19,7 +19,6 @@
  */
 
 public class Mail.MainWindow : Hdy.ApplicationWindow {
-    private Gtk.SearchEntry search_entry;
     private Gtk.Paned paned_end;
     private Gtk.Paned paned_start;
 
@@ -27,15 +26,8 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     private Gtk.Overlay view_overlay;
     private ConversationListBox conversation_list_box;
     private MessageList message_list;
-    private Granite.SwitchModelButton hide_read_switch;
-    private Granite.SwitchModelButton hide_unstarred_switch;
-    private Gtk.Button refresh_button;
-    private Gtk.MenuButton filter_button;
-    private Gtk.Spinner refresh_spinner;
-    private Gtk.Stack refresh_stack;
 
     private uint configure_id;
-    private uint search_changed_debounce_timeout_id = 0;
 
     public bool is_session_started { get; private set; default = false; }
     public signal void session_started ();
@@ -130,72 +122,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             }
         });
 
-        search_entry = new Gtk.SearchEntry () {
-            hexpand = true,
-            placeholder_text = _("Search Mail"),
-            valign = Gtk.Align.CENTER
-        };
-
-        var search_header = new Hdy.HeaderBar ();
-        search_header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        search_header.set_custom_title (search_entry);
-
-        refresh_button = new Gtk.Button.from_icon_name ("view-refresh-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_REFRESH
-        };
-
-        var application_instance = (Gtk.Application) GLib.Application.get_default ();
-        refresh_button.tooltip_markup = Granite.markup_accel_tooltip (
-            application_instance.get_accels_for_action (refresh_button.action_name),
-            _("Fetch new messages")
-        );
-
-        refresh_spinner = new Gtk.Spinner () {
-            active = true,
-            halign = Gtk.Align.CENTER,
-            valign = Gtk.Align.CENTER,
-            tooltip_text = _("Fetching new messages…")
-        };
-
-        refresh_stack = new Gtk.Stack () {
-            transition_type = Gtk.StackTransitionType.CROSSFADE
-        };
-        refresh_stack.add (refresh_button);
-        refresh_stack.add (refresh_spinner);
-        refresh_stack.visible_child = refresh_button;
-
-        hide_read_switch = new Granite.SwitchModelButton (_("Hide read conversations"));
-
-        hide_unstarred_switch = new Granite.SwitchModelButton (_("Hide unstarred conversations"));
-
-        var filter_menu_popover_box = new Gtk.Box (VERTICAL, 0) {
-            margin_bottom = 3,
-            margin_top = 3
-        };
-        filter_menu_popover_box.add (hide_read_switch);
-        filter_menu_popover_box.add (hide_unstarred_switch);
-        filter_menu_popover_box.show_all ();
-
-        var filter_popover = new Gtk.Popover (null);
-        filter_popover.add (filter_menu_popover_box);
-
-        filter_button = new Gtk.MenuButton () {
-            image = new Gtk.Image.from_icon_name ("mail-filter-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
-            popover = filter_popover,
-            tooltip_text = _("Filter Conversations")
-        };
-
-        var conversation_action_bar = new Gtk.ActionBar ();
-        conversation_action_bar.pack_start (refresh_stack);
-        conversation_action_bar.pack_end (filter_button);
-        conversation_action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var conversation_list_grid = new Gtk.Grid ();
-        conversation_list_grid.attach (search_header, 0, 0);
-        conversation_list_grid.attach (conversation_list_box, 0, 1);
-        conversation_list_grid.attach (conversation_action_bar, 0, 2);
-        conversation_list_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
-
         message_list = new MessageList ();
 
         view_overlay = new Gtk.Overlay () {
@@ -223,7 +149,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         paned_start = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_start.pack1 (folders_list_view, false, false);
-        paned_start.pack2 (conversation_list_grid, true, false);
+        paned_start.pack2 (conversation_list_box, true, false);
 
         paned_end = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned_end.pack1 (paned_start, false, false);
@@ -240,12 +166,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         var header_group = new Hdy.HeaderGroup ();
         header_group.add_header_bar (folders_list_view.header_bar);
-        header_group.add_header_bar (search_header);
+        header_group.add_header_bar (conversation_list_box.search_header);
         header_group.add_header_bar (message_list.headerbar);
 
         var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
         size_group.add_widget (folders_list_view.header_bar);
-        size_group.add_widget (search_header);
+        size_group.add_widget (conversation_list_box.search_header);
         size_group.add_widget (message_list.headerbar);
 
         var settings = new GLib.Settings ("io.elementary.mail");
@@ -260,33 +186,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         conversation_list_box.conversation_selected.connect (message_list.set_conversation);
 
-        search_entry.bind_property ("sensitive", filter_button, "sensitive", BindingFlags.SYNC_CREATE);
-
-        hide_read_switch.notify["active"].connect (on_filter_button_changed);
-        hide_unstarred_switch.notify["active"].connect (on_filter_button_changed);
-
-        search_entry.search_changed.connect (() => {
-            if (search_changed_debounce_timeout_id != 0) {
-                GLib.Source.remove (search_changed_debounce_timeout_id);
-            }
-
-            search_changed_debounce_timeout_id = GLib.Timeout.add (800, () => {
-                search_changed_debounce_timeout_id = 0;
-
-                var search_term = search_entry.text.strip ();
-                conversation_list_box.search.begin (search_term == "" ? null : search_term);
-
-                return GLib.Source.REMOVE;
-            });
-        });
-
         unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
 
         session.account_removed.connect (() => {
             var accounts_left = session.get_accounts ();
             if (accounts_left.size == 0) {
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (false);
-                search_entry.sensitive = false;
             }
         });
 
@@ -296,7 +201,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             if (session.get_accounts ().size > 0) {
                 placeholder_stack.visible_child = paned_end;
                 get_action (ACTION_COMPOSE_MESSAGE).set_enabled (true);
-                search_entry.sensitive = true;
             }
 
             is_session_started = true;
@@ -304,31 +208,12 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         });
     }
 
-    private void on_filter_button_changed () {
-        var style_context = filter_button.get_style_context ();
-        if (hide_read_switch.active || hide_unstarred_switch.active) {
-            if (!style_context.has_class (Granite.STYLE_CLASS_ACCENT)) {
-                style_context.add_class (Granite.STYLE_CLASS_ACCENT);
-            }
-        } else if (style_context.has_class (Granite.STYLE_CLASS_ACCENT)) {
-            style_context.remove_class (Granite.STYLE_CLASS_ACCENT);
-        }
-
-        conversation_list_box.search.begin (search_entry.text, hide_read_switch.active, hide_unstarred_switch.active);
-    }
-
     private void on_compose_message () {
         new ComposerWindow (this).show_all ();
     }
 
     private void on_refresh () {
-        refresh_stack.visible_child = refresh_spinner;
-
-        conversation_list_box.refresh_folder.begin (null, (obj, res) => {
-            conversation_list_box.refresh_folder.end (res);
-
-            refresh_stack.visible_child = refresh_button;
-        });
+        conversation_list_box.refresh_folder.begin ();
     }
 
     private void on_mark_read () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -140,13 +140,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         search_header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         search_header.set_custom_title (search_entry);
 
-        var conversation_list_scrolled = new Gtk.ScrolledWindow (null, null) {
-            hscrollbar_policy = Gtk.PolicyType.NEVER,
-            width_request = 158,
-            expand = true
-        };
-        conversation_list_scrolled.add (conversation_list_box);
-
         refresh_button = new Gtk.Button.from_icon_name ("view-refresh-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
             action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_REFRESH
         };
@@ -199,7 +192,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         var conversation_list_grid = new Gtk.Grid ();
         conversation_list_grid.attach (search_header, 0, 0);
-        conversation_list_grid.attach (conversation_list_scrolled, 0, 1);
+        conversation_list_grid.attach (conversation_list_box, 0, 1);
         conversation_list_grid.attach (conversation_action_bar, 0, 2);
         conversation_list_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -48,7 +48,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     public const string ACTION_MOVE_TO_TRASH = "trash";
     public const string ACTION_FULLSCREEN = "full-screen";
 
-    private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
+    public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
     private const ActionEntry[] ACTION_ENTRIES = {
         {ACTION_COMPOSE_MESSAGE, on_compose_message },
@@ -105,22 +105,6 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         folders_list_view = new FoldersListView ();
         conversation_list = new ConversationList ();
-
-        // Disable delete accelerators when the conversation list box loses keyboard focus,
-        // restore them when it returns
-        conversation_list.set_focus_child.connect ((widget) => {
-            if (widget == null) {
-                ((Gtk.Application) GLib.Application.get_default ()).set_accels_for_action (
-                    ACTION_PREFIX + ACTION_MOVE_TO_TRASH,
-                    {}
-                );
-            } else {
-                ((Gtk.Application) GLib.Application.get_default ()).set_accels_for_action (
-                    ACTION_PREFIX + ACTION_MOVE_TO_TRASH,
-                    action_accelerators[ACTION_MOVE_TO_TRASH].to_array ()
-                );
-            }
-        });
 
         message_list = new MessageList ();
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -180,9 +180,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
         destroy.connect (() => destroy ());
 
-        folders_list_view.folder_selected.connect ((folder_full_name_per_account) => {
-            conversation_list_box.load_folder.begin (folder_full_name_per_account);
-        });
+        folders_list_view.folder_selected.connect (conversation_list_box.load_folder);
 
         conversation_list_box.conversation_selected.connect (message_list.set_conversation);
 
@@ -248,9 +246,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     private void on_archive () {
-        conversation_list_box.archive_selected_messages.begin ((obj, res) => {
-            conversation_list_box.archive_selected_messages.end (res);
-        });
+        conversation_list_box.archive_selected_messages.begin ();
     }
 
     private void on_move_to_trash () {

--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -14,6 +14,8 @@ public class Mail.MessageList : Gtk.Box {
     private Gtk.ScrolledWindow scrolled_window;
 
     construct {
+        get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
+
         var application_instance = (Gtk.Application) GLib.Application.get_default ();
 
         var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));

--- a/src/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/VirtualizingListBox/VirtualizingListBox.vala
@@ -718,7 +718,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
     }
 
-    protected void select_row_at_index (int index) {
+    public void select_row_at_index (int index) {
         var row = ensure_index_visible (index);
 
         if (row != null) {
@@ -793,7 +793,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         return null;
     }
 
-    protected void select_row (VirtualizingListBoxRow row) {
+    public void select_row (VirtualizingListBoxRow row) {
         if (model.get_item_selected (row) || selection_mode == Gtk.SelectionMode.NONE) {
             return;
         }

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,7 +13,7 @@ vala_files = files(
     'Composer/ComposerWindow.vala',
     'Composer/InlineComposer.vala',
     'ConversationList/ConversationItemModel.vala',
-    'ConversationList/ConversationListBox.vala',
+    'ConversationList/ConversationList.vala',
     'ConversationList/ConversationListItem.vala',
     'ConversationList/ConversationListStore.vala',
     'Dialogs/InsertLinkDialog.vala',


### PR DESCRIPTION
This is being done in preparation for GTK4

- Derive `MessageListBox` from `Gtk.Box`
- Move corresponding stuff to `MessageListBox` from `MainWindow`
- Cleanup
- Rename to `MessageList`
- Update POTFILES

A few notes:
- The `search_changed` signal of a `Gtk.SearchEntry` has a default delay of 150 ms. I think that's reasonable enough so that we don't have to add another 800 ms of delay. This doesn't really impact performance for small folders, it even makes them seem more reactive and for large folders searching is pretty much broken anyway. Also the delay can be changed in GTK4 if we really would want a longer delay again.
- The `search_entry` and the `filter_button` were set to not be sensitive if no accounts have been added yet. I think this isn't necessary as they can't be focused or activated if there are no accounts present. But maybe I am missing something here, so correct me if I'm wrong.

This also seems to fix all of the annoying `_gtk_widget_get_preferred_size_for_size: assertion 'size >= -1' failed` criticals