### PR TITLE
MessageListItem: Use Popover instead of Gtk.Menu

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -222,17 +222,14 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
     }
 
     private void on_reply () {
-        message_list.scroll_to_bottom ();
         message_list.add_inline_composer.begin (ComposerWidget.Type.REPLY);
     }
 
     private void on_reply_all () {
-        message_list.scroll_to_bottom ();
         message_list.add_inline_composer.begin (ComposerWidget.Type.REPLY_ALL);
     }
 
     private void on_forward () {
-        message_list.scroll_to_bottom ();
         message_list.add_inline_composer.begin (ComposerWidget.Type.FORWARD);
     }
 

--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -229,10 +229,7 @@ public class Mail.MessageList : Gtk.Box {
         }
 
         if (node.message != null && Camel.MessageFlags.DRAFT in (int) node.message.flags) {
-            add_inline_composer.begin (ComposerWidget.Type.DRAFT, null, (obj, res) => {
-                add_inline_composer.end (res);
-                scroll_to_bottom ();
-            });
+            add_inline_composer.begin (ComposerWidget.Type.DRAFT, null);
         }
     }
 
@@ -275,6 +272,7 @@ public class Mail.MessageList : Gtk.Box {
             list_box.remove (composer);
             composer.destroy ();
         });
+        scroll_to_bottom ();
         list_box.add (composer);
         can_reply (false);
         can_move_thread (true);

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -203,25 +203,53 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         };
         starred_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var reply_item = new Gtk.MenuItem.with_label (_("Reply"));
-        reply_item.activate.connect (() => add_inline_composer (ComposerWidget.Type.REPLY));
+        var actions_menu_box = new Gtk.Box (VERTICAL, 0) {
+            margin_bottom = 3,
+            margin_top = 3
+        };
 
-        var reply_all_item = new Gtk.MenuItem.with_label (_("Reply to All"));
-        reply_all_item.activate.connect (() => add_inline_composer (ComposerWidget.Type.REPLY_ALL));
+        var actions_menu = new Gtk.Popover (null) {
+            child = actions_menu_box
+        };
 
-        var forward_item = new Gtk.MenuItem.with_label (_("Forward"));
-        forward_item.activate.connect (() => add_inline_composer (ComposerWidget.Type.FORWARD));
+        var reply_item = new Gtk.ModelButton () {
+            label = _("Reply")
+        };
+        reply_item.clicked.connect (() => {
+            add_inline_composer (ComposerWidget.Type.REPLY);
+            actions_menu.popdown ();
+        });
 
-        var print_item = new Gtk.MenuItem.with_label (_("Print…"));
-        print_item.activate.connect (on_print);
+        var reply_all_item = new Gtk.ModelButton () {
+            label = _("Reply to All")
+        };
+        reply_all_item.clicked.connect (() => {
+            add_inline_composer (ComposerWidget.Type.REPLY_ALL);
+            actions_menu.popdown ();
+        });
 
-        var actions_menu = new Gtk.Menu ();
-        actions_menu.add (reply_item);
-        actions_menu.add (reply_all_item);
-        actions_menu.add (forward_item);
-        actions_menu.add (new Gtk.SeparatorMenuItem ());
-        actions_menu.add (print_item);
-        actions_menu.show_all ();
+        var forward_item = new Gtk.ModelButton () {
+            label = _("Forward")
+        };
+        forward_item.clicked.connect (() => {
+            add_inline_composer (ComposerWidget.Type.FORWARD);
+            actions_menu.popdown ();
+        });
+
+        var print_item = new Gtk.ModelButton () {
+            label = _("Print…")
+        };
+        print_item.clicked.connect (() => {
+            on_print ();
+            actions_menu.popdown ();
+        });
+
+        actions_menu_box.add (reply_item);
+        actions_menu_box.add (reply_all_item);
+        actions_menu_box.add (forward_item);
+        actions_menu_box.add (new Gtk.Separator (HORIZONTAL) { margin_top = 3, margin_bottom = 3 });
+        actions_menu_box.add (print_item);
+        actions_menu_box.show_all ();
 
         var actions_menu_button = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("view-more-symbolic", Gtk.IconSize.MENU),
@@ -229,7 +257,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             margin_top = 6,
             valign = START,
             halign = END,
-            popup = actions_menu
+            popover = actions_menu
         };
         actions_menu_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -213,7 +213,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         };
 
         var reply_item = new Gtk.ModelButton () {
-            label = _("Reply")
+            text = _("Reply")
         };
         reply_item.clicked.connect (() => {
             add_inline_composer (ComposerWidget.Type.REPLY);
@@ -221,7 +221,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         });
 
         var reply_all_item = new Gtk.ModelButton () {
-            label = _("Reply to All")
+            text = _("Reply to All")
         };
         reply_all_item.clicked.connect (() => {
             add_inline_composer (ComposerWidget.Type.REPLY_ALL);
@@ -229,7 +229,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         });
 
         var forward_item = new Gtk.ModelButton () {
-            label = _("Forward")
+            text = _("Forward")
         };
         forward_item.clicked.connect (() => {
             add_inline_composer (ComposerWidget.Type.FORWARD);
@@ -237,7 +237,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         });
 
         var print_item = new Gtk.ModelButton () {
-            label = _("Print…")
+            text = _("Print…")
         };
         print_item.clicked.connect (() => {
             on_print ();


### PR DESCRIPTION
Once again preparation for GTK4

Also move `scroll_to_bottom` calls to `MessageList`'s `add_inline_composer` and thus fix #763.