### PR TITLE
ConversationList: Move context menu to popover

### DIFF
--- a/src/ConversationList/ConversationList.vala
+++ b/src/ConversationList/ConversationList.vala
@@ -582,7 +582,7 @@ public class Mail.ConversationList : Gtk.Box {
         var item = (ConversationItemModel)row.model_item;
 
         var menu = new Menu ();
-        menu.append(_("Move To Trash"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MOVE_TO_TRASH);
+        menu.append (_("Move To Trash"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MOVE_TO_TRASH);
         if (!item.unread) {
             menu.append (_("Mark As Unread"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MARK_UNREAD);
         } else {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -207,18 +207,26 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
     private void on_mark_read () {
         conversation_list.mark_read_selected_messages ();
+        get_action (ACTION_MARK_READ).set_enabled (false);
+        get_action (ACTION_MARK_UNREAD).set_enabled (true);
     }
 
     private void on_mark_star () {
         conversation_list.mark_star_selected_messages ();
+        get_action (ACTION_MARK_STAR).set_enabled (false);
+        get_action (ACTION_MARK_UNSTAR).set_enabled (true);
     }
 
     private void on_mark_unread () {
         conversation_list.mark_unread_selected_messages ();
+        get_action (ACTION_MARK_UNREAD).set_enabled (false);
+        get_action (ACTION_MARK_READ).set_enabled (true);
     }
 
     private void on_mark_unstar () {
         conversation_list.mark_unstar_selected_messages ();
+        get_action (ACTION_MARK_UNSTAR).set_enabled (false);
+        get_action (ACTION_MARK_STAR).set_enabled (true);
     }
 
     private void on_reply () {


### PR DESCRIPTION
Preparation for GTK4

Currently this means that the context menu will have an arrow and won't show keyboard shortcuts, both of which will be fixed with GTK4. So should this be merged now or included in the GTK4 port?

This also fixes an issue that caused the wrong menuitems to appear in the headerbar markmenu after one of them was clicked.