### PR TITLE
Application.css: add scrolledwindow undershoot

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -1,3 +1,12 @@
+.titlebar + scrolledwindow undershoot.top {
+    background:
+        linear-gradient(
+            @borders,
+            alpha(black, 0.05) 1px,
+            alpha(black, 0.0) 0.444rem
+        );
+}
+
 .card.collapsed {
     margin-bottom: -64px;
 }


### PR DESCRIPTION
Just a little magic to make it look like headerbars float above scrolled content

![Screenshot from 2023-04-13 17 01 05](https://user-images.githubusercontent.com/7277719/231908379-995753e9-28d9-4da1-9725-852508f6bef3.png)
