### PR TITLE
WebView: Update height after images were loaded

### DIFF
--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -31,7 +31,6 @@ public class Mail.WebView : WebKit.WebView {
     private const string INTERNAL_URL_BODY = "elementary-mail:body";
     private const string SERVER_BUS_NAME = "io.elementary.mail.WebViewServer";
 
-    private int preferred_height = 0;
     private Gee.Map<string, InputStream> internal_resources;
 
     private bool loaded = false;
@@ -55,7 +54,8 @@ public class Mail.WebView : WebKit.WebView {
 
     construct {
         cancellable = new GLib.Cancellable ();
-        expand = true;
+        vexpand = true;
+        hexpand = true;
 
         internal_resources = new Gee.HashMap<string, InputStream> ();
 
@@ -93,7 +93,7 @@ public class Mail.WebView : WebKit.WebView {
             send_message_to_page.begin (message, cancellable, (obj, res) => {
                 try {
                     var response = send_message_to_page.end (res);
-                    preferred_height = response.parameters.get_int32 ();
+                    height_request = response.parameters.get_int32 ();
                     queue_resize ();
                 } catch (Error e) {
                     // We can cancel the operation
@@ -116,10 +116,6 @@ public class Mail.WebView : WebKit.WebView {
 
             load_finished ();
         }
-    }
-
-    public override void get_preferred_height (out int minimum_height, out int natural_height) {
-        minimum_height = natural_height = preferred_height;
     }
 
     public new void load_html (string? body) {

--- a/src/WebView.vala
+++ b/src/WebView.vala
@@ -88,14 +88,13 @@ public class Mail.WebView : WebKit.WebView {
         cancellable.cancel ();
     }
 
-    public void on_load_changed (WebKit.LoadEvent event) {
+    private void on_load_changed (WebKit.LoadEvent event) {
         if (event == WebKit.LoadEvent.FINISHED || event == WebKit.LoadEvent.COMMITTED) {
             var message = new WebKit.UserMessage ("get-page-height", null);
             send_message_to_page.begin (message, cancellable, (obj, res) => {
                 try {
                     var response = send_message_to_page.end (res);
                     height_request = response.parameters.get_int32 ();
-                    queue_resize ();
                 } catch (Error e) {
                     // We can cancel the operation
                     if (!(e is GLib.IOError.CANCELLED)) {


### PR DESCRIPTION
- After images were loaded get the new height of the webpage displaying the message content  and update the webviews `height_request`
- Fixes an issue that caused the webview to not be high enough to display the whole message content after images were loaded. This made the webview scrollable which caused some weird behavior with having two scrollable containers.
- Also make a unnecessarily public method private

Based on #874 

Fixes #822 