### PR TITLE
MessageList: Rewrite headers

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -7,8 +7,22 @@
         );
 }
 
-.card.collapsed {
-    margin-bottom: -64px;
+.message-list list {
+    padding: 0 1rem 0.25rem;
+}
+
+.message-list list > .h4 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    padding: 0.75rem 0;
+}
+
+.message-list-item {
+    margin: 0.75rem 0;
+}
+
+.message-list-item.collapsed {
+    margin: 0.5rem 0;
 }
 
 .conversation-list-item {

--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -15,6 +15,7 @@ public class Mail.MessageList : Gtk.Box {
 
     construct {
         get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
+        get_style_context ().add_class ("message-list");
 
         var application_instance = (Gtk.Application) GLib.Application.get_default ();
 
@@ -169,6 +170,7 @@ public class Mail.MessageList : Gtk.Box {
         list_box.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
         list_box.set_placeholder (placeholder);
         list_box.set_sort_func (message_sort_function);
+        list_box.set_header_func (message_header_func);
 
         scrolled_window = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = NEVER
@@ -298,6 +300,35 @@ public class Mail.MessageList : Gtk.Box {
         ((SimpleAction) main_window.lookup_action (MainWindow.ACTION_ARCHIVE)).set_enabled (enabled);
         ((SimpleAction) main_window.lookup_action (MainWindow.ACTION_MARK)).set_enabled (enabled);
         ((SimpleAction) main_window.lookup_action (MainWindow.ACTION_MOVE_TO_TRASH)).set_enabled (enabled);
+    }
+
+    private void message_header_func (Gtk.ListBoxRow row, Gtk.ListBoxRow? before) {
+        unowned var message = (MessageListItem) row;
+        unowned var message_before = (MessageListItem) before;
+
+        var subject = message.message_info.subject;
+
+        if (message_before == null || message_before != null && sanitize_subject (message_before.message_info.subject) != sanitize_subject (subject)) {
+            if (subject == "") {
+                subject = _("No Subject");
+            }
+
+            var header_label = new Granite.HeaderLabel (subject) {
+                wrap = true,
+            };
+
+            row.set_header (header_label);
+        }
+    }
+
+    private string sanitize_subject (string _subject) {
+        var subject = _subject.down ();
+        subject = subject.replace (" ", "");
+        subject = subject.replace (":", "");
+        subject = subject.replace ("re", "");
+        subject = subject.replace ("fwd", "");
+
+        return subject;
     }
 
     private static int message_sort_function (Gtk.ListBoxRow item1, Gtk.ListBoxRow item2) {

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -200,15 +200,14 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         };
         actions_menu_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var header = new Gtk.Grid () {
+        var header = new Gtk.Box (HORIZONTAL, 12) {
             margin_top = 12,
             margin_bottom = 12,
             margin_start = 12,
-            margin_end = 12,
-            column_spacing = 12
+            margin_end = 12
         };
-        header.attach (avatar, 0, 0, 1);
-        header.attach (fields_grid, 1, 0, 1);
+        header.add (avatar);
+        header.add (fields_grid);
 
         var header_event_box = new Gtk.EventBox ();
         header_event_box.events |= Gdk.EventMask.ENTER_NOTIFY_MASK;

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -257,6 +257,18 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         secondary_box.add (blocked_images_infobar);
         secondary_box.add (web_view);
 
+        secondary_revealer = new Gtk.Revealer () {
+            transition_type = SLIDE_UP
+        };
+        secondary_revealer.add (secondary_box);
+
+        var base_box = new Gtk.Box (VERTICAL, 0) {
+            hexpand = true,
+            vexpand = true
+        };
+        base_box.add (header_event_box);
+        base_box.add (secondary_revealer);
+
         if (Camel.MessageFlags.ATTACHMENTS in (int) message_info.flags) {
             var attachment_icon = new Gtk.Image.from_icon_name ("mail-attachment-symbolic", Gtk.IconSize.MENU) {
                 tooltip_text = _("This message contains one or more attachments")
@@ -274,18 +286,6 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
         action_box.add (starred_button);
         action_box.add (actions_menu_button);
-
-        secondary_revealer = new Gtk.Revealer () {
-            transition_type = SLIDE_UP
-        };
-        secondary_revealer.add (secondary_box);
-
-        var base_box = new Gtk.Box (VERTICAL, 0) {
-            hexpand = true,
-            vexpand = true
-        };
-        base_box.add (header_event_box);
-        base_box.add (secondary_revealer);
 
         add (base_box);
         expanded = false;


### PR DESCRIPTION
Makes expanded headers much more compact and makes it much easier to navigate conversations with changing subjects

* Use CSS to set padding and margins
* Show a subject header in the message list only when it changes instead in every message
* Slightly reduce the size of Avatars
* Don't show the "From:" label. Other fields like to, cc, bcc etc need disambiguation, but I think this is fairly clear that this first line is the sender
* Put all the actions in a row. This prevents things from moving around when messages have attachments etc
* Don't do clever overlapping with collapsed messages and always use the same header. A little less clever but things are always visible

## BEFORE
![Screenshot from 2023-05-17 14 52 19](https://github.com/elementary/mail/assets/7277719/361cf168-529a-4b63-a45d-fbb5e3679384)

## AFTER
![Screenshot from 2023-05-17 14 48 08](https://github.com/elementary/mail/assets/7277719/796d78fc-720b-473b-9352-1ba11a13eb5e)
