### PR TITLE
Fix an issue that causes mail to never connect to the network

### DIFF
--- a/src/Backend/Account.vala
+++ b/src/Backend/Account.vala
@@ -37,6 +37,7 @@ public class Mail.Backend.Account : GLib.Object {
             try {
                 yield offlinestore.set_online (true, GLib.Priority.DEFAULT, null);
                 yield offlinestore.synchronize (false, GLib.Priority.DEFAULT, null);
+                debug ("Account '%s' connected to remote server.", service.display_name);
             } catch (Error e) {
                 /* Don't show an error when the network is unavailable as it can be thrown when trying to connect
                    although the internet connection isn't fully available yet or on a rapid change of the connection */
@@ -65,6 +66,7 @@ public class Mail.Backend.Account : GLib.Object {
 
         try {
             yield offlinestore.set_online (false, GLib.Priority.DEFAULT, null);
+            debug ("Account '%s' disconnected from remote server.", service.display_name);
         } catch (Error e) {
             if (e is Camel.ServiceError.UNAVAILABLE || e is GLib.IOError.CANCELLED) {
                 debug (e.message);

--- a/src/Backend/Session.vala
+++ b/src/Backend/Session.vala
@@ -49,7 +49,7 @@ public class Mail.Backend.Session : Camel.Session {
         set_network_monitor (network_monitor);
 
         network_monitor.network_changed.connect (set_online);
-        set_online (network_monitor.network_available);
+        set_online (true);
     }
 
     public async void start () {


### PR DESCRIPTION
- Fix an issue that was introduced with #871 that causes mail to not connect to the network because `NetworkMonitor.network_available` is for some reason `false` in the beginning. To do this we set `Session.online` to true by default (which btw is also the default if it's not set at all but I think it's better to keep explicitly setting it to avoid confusion) 
- Add some debug messages
- Alternatively we could also use GLib.NetworkMonitor which reports a change in the beginning so a connection is established because of the signal connection (might be better but I would leave this to a different PR to get the issue at hand fixed ASAP)

I'm so sorry, I had this commit locally but forgot to push 😬