### PR TITLE
Move menu to FoldersListView

### DIFF
--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -134,9 +134,9 @@ public class Mail.FoldersListView : Gtk.Grid {
 
         account_settings_menuitem.clicked.connect (() => {
             try {
-                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+                Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), "settings://accounts/online", Gdk.CURRENT_TIME);
             } catch (Error e) {
-                warning ("Failed to open account settings: %s", e.message);
+                critical ("Failed to open account settings: %s", e.message);
             }
         });
     }

--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -56,11 +56,47 @@ public class Mail.FoldersListView : Gtk.Grid {
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
         scrolled_window.add (source_list);
 
+        var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));
+
+        var account_settings_menuitem = new Gtk.ModelButton () {
+            text = _("Account Settings…")
+        };
+
+        var app_menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            margin_bottom = 3,
+            margin_top = 3
+        };
+
+        var app_menu_grid = new Gtk.Grid () {
+            margin_bottom = 3,
+            margin_top = 3,
+            orientation = Gtk.Orientation.VERTICAL
+        };
+        app_menu_grid.add (load_images_menuitem);
+        app_menu_grid.add (app_menu_separator);
+        app_menu_grid.add (account_settings_menuitem);
+        app_menu_grid.show_all ();
+
+        var app_menu_popover = new Gtk.Popover (null) {
+            child = app_menu_grid
+        };
+
+        var app_menu = new Gtk.MenuButton () {
+            image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+            popover = app_menu_popover,
+            tooltip_text = _("Menu")
+        };
+
+        var action_bar = new Gtk.ActionBar ();
+        action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        action_bar.pack_end (app_menu);
+
         orientation = Gtk.Orientation.VERTICAL;
         width_request = 100;
         get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
         add (header_bar);
         add (scrolled_window);
+        add (action_bar);
 
         var session = Mail.Backend.Session.get_default ();
 
@@ -91,6 +127,17 @@ public class Mail.FoldersListView : Gtk.Grid {
                 folder_selected (grouped_folder_item.get_folder_full_name_per_account ());
 
                 settings.set ("selected-folder", "(ss)", "GROUPED", grouped_folder_item.name);
+            }
+        });
+
+        var settings = new GLib.Settings ("io.elementary.mail");
+        settings.bind ("always-load-remote-images", load_images_menuitem, "active", SettingsBindFlags.DEFAULT);
+
+        account_settings_menuitem.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
+            } catch (Error e) {
+                warning ("Failed to open account settings: %s", e.message);
             }
         });
     }

--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -136,7 +136,17 @@ public class Mail.FoldersListView : Gtk.Grid {
             try {
                 Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), "settings://accounts/online", Gtk.get_current_event_time ());
             } catch (Error e) {
-                critical ("Failed to open account settings: %s", e.message);
+                var dialog = new Granite.MessageDialog (
+                    _("Unable to open System Settings"),
+                    _("Open System Settings manually or install Evolution to set up online accounts."),
+                    new ThemedIcon ("preferences-system")
+                ) {
+                    badge_icon = new ThemedIcon ("dialog-warning"),
+                    modal = true,
+                    transient_for = (Gtk.Window) get_toplevel ()
+                };
+                dialog.response.connect (dialog.destroy);
+                dialog.present ();
             }
         });
     }

--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -67,18 +67,17 @@ public class Mail.FoldersListView : Gtk.Grid {
             margin_top = 3
         };
 
-        var app_menu_grid = new Gtk.Grid () {
+        var app_menu_box = new Gtk.Box (VERTICAL, 0) {
             margin_bottom = 3,
-            margin_top = 3,
-            orientation = Gtk.Orientation.VERTICAL
+            margin_top = 3
         };
-        app_menu_grid.add (load_images_menuitem);
-        app_menu_grid.add (app_menu_separator);
-        app_menu_grid.add (account_settings_menuitem);
-        app_menu_grid.show_all ();
+        app_menu_box.add (load_images_menuitem);
+        app_menu_box.add (app_menu_separator);
+        app_menu_box.add (account_settings_menuitem);
+        app_menu_box.show_all ();
 
         var app_menu_popover = new Gtk.Popover (null) {
-            child = app_menu_grid
+            child = app_menu_box
         };
 
         var app_menu = new Gtk.MenuButton () {

--- a/src/FoldersView/FoldersListView.vala
+++ b/src/FoldersView/FoldersListView.vala
@@ -134,7 +134,7 @@ public class Mail.FoldersListView : Gtk.Grid {
 
         account_settings_menuitem.clicked.connect (() => {
             try {
-                Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), "settings://accounts/online", Gdk.CURRENT_TIME);
+                Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), "settings://accounts/online", Gtk.get_current_event_time ());
             } catch (Error e) {
                 critical ("Failed to open account settings: %s", e.message);
             }

--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -20,35 +20,6 @@ public class Mail.MessageList : Gtk.Box {
 
         var application_instance = (Gtk.Application) GLib.Application.get_default ();
 
-        var load_images_menuitem = new Granite.SwitchModelButton (_("Always Show Remote Images"));
-
-        var account_settings_menuitem = new Gtk.ModelButton () {
-            text = _("Account Settings…")
-        };
-
-        var app_menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
-            margin_bottom = 3,
-            margin_top = 3
-        };
-
-        var app_menu_box = new Gtk.Box (VERTICAL, 0) {
-            margin_bottom = 3,
-            margin_top = 3
-        };
-        app_menu_box.add (load_images_menuitem);
-        app_menu_box.add (app_menu_separator);
-        app_menu_box.add (account_settings_menuitem);
-        app_menu_box.show_all ();
-
-        var app_menu_popover = new Gtk.Popover (null);
-        app_menu_popover.add (app_menu_box);
-
-        var app_menu = new Gtk.MenuButton () {
-            image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),
-            popover = app_menu_popover,
-            tooltip_text = _("Menu")
-        };
-
         var reply_button = new Gtk.Button.from_icon_name ("mail-reply-sender", Gtk.IconSize.LARGE_TOOLBAR) {
             action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_REPLY,
             action_target = ""
@@ -147,23 +118,10 @@ public class Mail.MessageList : Gtk.Box {
         headerbar.pack_start (reply_button);
         headerbar.pack_start (reply_all_button);
         headerbar.pack_start (forward_button);
-        headerbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        headerbar.pack_start (mark_button);
-        headerbar.pack_start (move_button);
-        headerbar.pack_start (archive_button);
-        headerbar.pack_start (trash_button);
-        headerbar.pack_end (app_menu);
-
-        var settings = new GLib.Settings ("io.elementary.mail");
-        settings.bind ("always-load-remote-images", load_images_menuitem, "active", SettingsBindFlags.DEFAULT);
-
-        account_settings_menuitem.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("settings://accounts/online", null);
-            } catch (Error e) {
-                warning ("Failed to open account settings: %s", e.message);
-            }
-        });
+        headerbar.pack_end (trash_button);
+        headerbar.pack_end (archive_button);
+        headerbar.pack_end (move_button);
+        headerbar.pack_end (mark_button);
 
         var placeholder = new Gtk.Label (_("No Message Selected")) {
             visible = true


### PR DESCRIPTION
![Screenshot from 2023-05-31 11 40 20](https://github.com/elementary/mail/assets/7277719/03d279b4-648e-423c-97eb-68c9de4623a1)

* Makes room for the undo toast so it's less likely to cover buttons
* Settings related to the whole app/accounts aren't in the deepest pane, this will probably matter more for responsive/mobile but it makes them less logically connected to the messages list