### PR TITLE
CellRendererBadge: Remove reference of non-existent image

### DIFF
--- a/src/SourceList/CellRendererBadge.vala
+++ b/src/SourceList/CellRendererBadge.vala
@@ -11,8 +11,6 @@
  * it might be used to show how much songs are in a playlist or how much updates
  * are available.
  *
- * {{../doc/images/cellrendererbadge.png}}
- *
  * @since 0.2
  */
 public class Mail.CellRendererBadge : Gtk.CellRenderer {


### PR DESCRIPTION
I was rebasing a downstream [valadoc patch](https://github.com/NixOS/nixpkgs/pull/241298) and was looking for random projects (which build docs with valadoc) to test my patch and accidently find the `-Ddocumentation=true` build here fails :see_no_evil: 

```
[209/242] Generating docs/full documentation with a custom command
FAILED: docs/full
...
CellRendererBadge.vala: Mail.CellRendererBadge: {{:  error: '../doc/images/cellrendererbadge.png' does not exist
...
Failed: 1 error(s), 4 warning(s)
```

Tested building and browsing the docs:

<img src="https://github.com/elementary/mail/assets/20080233/69b1505d-e961-477f-946b-237c49b99652" width=50%>
