### PR TITLE
Metainfo: Distinguish the mails themselves and the app name

### DIFF
--- a/data/mail.metainfo.xml.in
+++ b/data/mail.metainfo.xml.in
@@ -75,7 +75,7 @@
           <li>Move settings menu to the mailboxes pane</li>
           <li>Use the FileChooser portal</li>
           <li>Improve network availability handling</li>
-          <li>Fix issues with fetching mails when Mail is not autostarted</li>
+          <li>Fix issues with fetching e-mail when Mail is not autostarted</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/data/mail.metainfo.xml.in
+++ b/data/mail.metainfo.xml.in
@@ -75,7 +75,7 @@
           <li>Move settings menu to the mailboxes pane</li>
           <li>Use the FileChooser portal</li>
           <li>Improve network availability handling</li>
-          <li>Fix issues with fetching Mail when it is not autostarted</li>
+          <li>Fix issues with fetching mails when Mail is not autostarted</li>
           <li>Updated translations</li>
         </ul>
       </description>


### PR DESCRIPTION
The app name and the mails themselves may be translated to different words in some languages, so I guess we may want to distinguish these two things here