### PR TITLE
Fix grouped archive folder

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -63,7 +63,7 @@ public class Mail.Utils {
     }
 
     public static string? strip_folder_full_name (string service_uid, string? folder_uri) {
-        if (folder_uri != null) {
+        if (folder_uri != null && folder_uri.strip () != "") {
             return folder_uri.replace ("folder://%s/".printf (service_uid), "");
         }
 


### PR DESCRIPTION
For some mail accounts the grouped archive folder displayed the inbox if no archive was found. That was because calling `get_folder_info` with an empty string returned the Inbox folder for some mail accounts (e.g. `t-online.de` accounts). Now we make sure that we return `null` instead of an empty string in `Utils.strip_folder_full_name` when a given folder uri is empty.