### PR TITLE
Refresh folder when selecting it

### DIFF
--- a/src/ConversationList/ConversationList.vala
+++ b/src/ConversationList/ConversationList.vala
@@ -311,6 +311,8 @@ public class Mail.ConversationList : Gtk.Box {
         }
 
         list_store.items_changed (0, 0, list_store.get_n_items ());
+
+        refresh_folder.begin (cancellable);
     }
 
     public async void refresh_folder (GLib.Cancellable? cancellable = null) {


### PR DESCRIPTION
Fixes an issue that when adding a new account the messages in its folders wouldn't show up right away but first after the folder was at least once manually refreshed.