### PR TITLE
MessageListItem: Fix resizing

### DIFF
--- a/src/MessageList/AttachmentButton.vala
+++ b/src/MessageList/AttachmentButton.vala
@@ -90,7 +90,9 @@ public class AttachmentButton : Gtk.FlowBoxChild {
         };
 
         name_label = new Gtk.Label (mime_part.get_filename ()) {
-            xalign = 0
+            xalign = 0,
+            wrap = true,
+            wrap_mode = WORD_CHAR
         };
 
         size_label = new Gtk.Label (null) {

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -195,9 +195,9 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
         ///TRANSLATORS: The first %s represents the date and the second %s the time of the message (either when it was received or sent)
         var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).to_local ().format (_("%s at %s").printf (date_format, time_format))) {
-            ellipsize = MIDDLE
+            wrap = true,
+            wrap_mode = WORD
         };
-        datetime_label.tooltip_text = datetime_label.label;
         datetime_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         var starred_icon = new Gtk.Image ();

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -120,18 +120,21 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         var from_val_label = new Gtk.Label (message_info.from) {
             wrap = true,
             wrap_mode = WORD_CHAR,
+            width_chars = 10,
             xalign = 0
         };
 
         var to_val_label = new Gtk.Label (message_info.to) {
             wrap = true,
             wrap_mode = WORD_CHAR,
+            width_chars = 10,
             xalign = 0
         };
 
         var subject_val_label = new Gtk.Label (message_info.subject) {
             wrap = true,
             wrap_mode = WORD_CHAR,
+            width_chars = 10,
             xalign = 0
         };
 
@@ -156,6 +159,8 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
             var cc_val_label = new Gtk.Label (cc_info) {
                 wrap = true,
+                wrap_mode = WORD_CHAR,
+                width_chars = 10,
                 xalign = 0
             };
 
@@ -189,7 +194,10 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         var time_format = Granite.DateTime.get_default_time_format (desktop_settings.get_enum ("clock-format") == 1, false);
 
         ///TRANSLATORS: The first %s represents the date and the second %s the time of the message (either when it was received or sent)
-        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).to_local ().format (_("%s at %s").printf (date_format, time_format)));
+        var datetime_label = new Gtk.Label (new DateTime.from_unix_utc (relevant_timestamp).to_local ().format (_("%s at %s").printf (date_format, time_format))) {
+            ellipsize = MIDDLE
+        };
+        datetime_label.tooltip_text = datetime_label.label;
         datetime_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         var starred_icon = new Gtk.Image ();

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -119,16 +119,19 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
 
         var from_val_label = new Gtk.Label (message_info.from) {
             wrap = true,
+            wrap_mode = WORD_CHAR,
             xalign = 0
         };
 
         var to_val_label = new Gtk.Label (message_info.to) {
             wrap = true,
+            wrap_mode = WORD_CHAR,
             xalign = 0
         };
 
         var subject_val_label = new Gtk.Label (message_info.subject) {
             wrap = true,
+            wrap_mode = WORD_CHAR,
             xalign = 0
         };
 


### PR DESCRIPTION
Fixes some annoying resizing of the window or the paned position when the window is small and sender/recipient addresses or the subject include a long word by using the wrap mode `WORD_CHAR`.