### PR TITLE
Use the actual recipients of a message as sender when replying or forwarding

### DIFF
--- a/src/Composer.vala
+++ b/src/Composer.vala
@@ -554,6 +554,8 @@ public class Mail.Composer : Hdy.ApplicationWindow {
             bool found = false;
 
             if (type != DRAFT) {
+                // Try to preselect the email address the message was sent to when replying.
+                // This method is preferred to the fallback below because it handles aliases.
                 Camel.InternetAddress recipients = new Camel.InternetAddress ();
 
                 unowned var to_recipients = message.get_recipients (Camel.RECIPIENT_TYPE_TO);
@@ -588,6 +590,8 @@ public class Mail.Composer : Hdy.ApplicationWindow {
                 }
             }
 
+            // If no matching address was found fall back to using the address
+            // associated with the E.Source the message belongs to
             if (!found) {
                 unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
                 unowned var account_source_uid = message.get_source ();

--- a/src/Composer.vala
+++ b/src/Composer.vala
@@ -551,33 +551,72 @@ public class Mail.Composer : Hdy.ApplicationWindow {
         }
 
         if (from_combo.model.iter_n_children (null) > 1) {
-            unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
-            unowned var account_source_uid = message.get_source ();
-            var account_source = session.ref_source (account_source_uid);
+            bool found = false;
 
-            if (account_source != null && account_source.has_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT)) {
-                unowned var account_extension = (E.SourceMailAccount) account_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+            if (type != DRAFT) {
+                Camel.InternetAddress recipients = new Camel.InternetAddress ();
 
-                var identity_uid = account_extension.identity_uid;
-                if (identity_uid != null && identity_uid != "") {
-                    var identity_source = session.ref_source (identity_uid);
+                unowned var to_recipients = message.get_recipients (Camel.RECIPIENT_TYPE_TO);
+                if (to_recipients != null) {
+                    recipients.cat (to_recipients);
+                }
+                unowned var cc_recipients = message.get_recipients (Camel.RECIPIENT_TYPE_CC);
+                if (cc_recipients != null) {
+                    recipients.cat (cc_recipients);
+                }
+                unowned var bcc_recipients = message.get_recipients (Camel.RECIPIENT_TYPE_BCC);
+                if (bcc_recipients != null) {
+                    recipients.cat (bcc_recipients);
+                }
 
-                    if (identity_source != null && identity_source.has_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY)) {
-                        unowned var identity_extension = (E.SourceMailIdentity) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY);
+                int i = 0;
+                unowned string address;
+                while (recipients.get (i, null, out address) && !found) {
+                    i++;
+                    from_combo.model.foreach ((model, path, iter) => {
+                        GLib.Value value;
+                        model.get_value (iter, 0, out value);
 
-                        var identity_address = identity_extension.get_address ();
-                        if (identity_address != "") {
-                            from_combo.model.foreach ((model, path, iter) => {
-                                GLib.Value value;
-                                model.get_value (iter, 0, out value);
+                        if (value.get_string () == address) {
+                            from_combo.set_active_iter (iter);
+                            found = true;
+                            return true;
+                        }
 
-                                if (value.get_string () == identity_address) {
-                                    from_combo.set_active_iter (iter);
-                                    return true;
-                                }
+                        return false;
+                    });
+                }
+            }
 
-                                return false;
-                            });
+            if (!found) {
+                unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
+                unowned var account_source_uid = message.get_source ();
+                var account_source = session.ref_source (account_source_uid);
+
+                if (account_source != null && account_source.has_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT)) {
+                    unowned var account_extension = (E.SourceMailAccount) account_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+
+                    var identity_uid = account_extension.identity_uid;
+                    if (identity_uid != null && identity_uid != "") {
+                        var identity_source = session.ref_source (identity_uid);
+
+                        if (identity_source != null && identity_source.has_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY)) {
+                            unowned var identity_extension = (E.SourceMailIdentity) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY);
+
+                            var identity_address = identity_extension.get_address ();
+                            if (identity_address != "") {
+                                from_combo.model.foreach ((model, path, iter) => {
+                                    GLib.Value value;
+                                    model.get_value (iter, 0, out value);
+
+                                    if (value.get_string () == identity_address) {
+                                        from_combo.set_active_iter (iter);
+                                        return true;
+                                    }
+
+                                    return false;
+                                });
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This fixes an issue that occurred when replying to a message received by an alias. Then the pre-selected sender would be the main address.