### PR TITLE
Fix some attachments not showing up

### DIFF
--- a/src/Composer.vala
+++ b/src/Composer.vala
@@ -685,7 +685,7 @@ public class Mail.Composer : Hdy.ApplicationWindow {
             for (uint i = 0; i < content.get_number (); i++) {
                 unowned var part = content.get_part (i);
                 unowned var field = part.get_mime_type_field ();
-                if (part.disposition == "attachment") {
+                if (part.get_content_disposition ().is_attachment (part.get_content_type ())) {
                     try {
                         if (tmp_dir == null) {
                             tmp_dir = GLib.File.new_for_path (GLib.DirUtils.make_tmp (".XXXXXX"));

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -594,7 +594,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
                 var field = part.get_mime_type_field ();
                 if (part.disposition == "inline") {
                     yield handle_inline_mime (part);
-                } else if (part.disposition == "attachment") {
+                } else if (part.get_content_disposition ().is_attachment (part.get_content_type ())) {
                     var button = new AttachmentButton (part, loading_cancellable);
                     button.activate.connect (() => show_attachment (button.mime_part));
                     attachment_bar.add (button);


### PR DESCRIPTION
Fix some attachments not showing up.

Tries to fix #957  

Only for reference if this doesn't work: the evolution way of getting whether a part is an attachment is (I think) found [here](https://github.com/GNOME/evolution/blob/70d6fcc6c1dcb73a0f8f121df4db9cd782c91a9e/src/em-format/e-mail-part-utils.c#L265)