### PR TITLE
Allow donating a message to elementary

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -24,7 +24,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
 
     private FoldersListView folders_list_view;
     private Granite.Widgets.Toast move_toast;
-    private Granite.Widgets.Toast error_toast;
+    private Granite.Widgets.Toast info_toast;
     private ConversationList conversation_list;
     private MessageList message_list;
 
@@ -128,9 +128,9 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             MoveOperation.undo_last_move ();
         });
 
-        error_toast = new Granite.Widgets.Toast ("");
-        error_toast.show_all ();
-        view_overlay.add_overlay (error_toast);
+        info_toast = new Granite.Widgets.Toast ("");
+        info_toast.show_all ();
+        view_overlay.add_overlay (info_toast);
 
         var message_overlay = new Granite.Widgets.OverlayBar (view_overlay);
         message_overlay.no_show_all = true;
@@ -344,7 +344,7 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
         return (SimpleAction) lookup_action (name);
     }
 
-    public static void send_error_message (string title, string description, string? icon_name = null) {
+    public static void send_error_message (string title, string description, string? icon_name = null, string? error_details = null) {
         var dialog = new Granite.MessageDialog (
             title,
             description,
@@ -359,8 +359,17 @@ public class Mail.MainWindow : Hdy.ApplicationWindow {
             dialog.badge_icon = new ThemedIcon ("dialog-error");
         }
 
+        if (error_details != null) {
+            dialog.show_error_details (error_details);
+        }
+
         dialog.present ();
         dialog.response.connect (dialog.destroy);
+    }
+
+    public void send_info_toast (string title) {
+        info_toast.title = title;
+        info_toast.send_notification ();
     }
 
     public override bool configure_event (Gdk.EventConfigure event) {

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -316,11 +316,24 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             loaded = true;
         });
 
+        var donate_label = new Gtk.Label (_("The message isn't displayed correctly?") + " ");
+        var donate_link = new Gtk.LinkButton.with_label ("", _("Donate it to elementary for debugging purposes."));
+
+        var donate_box = new Gtk.Box (HORIZONTAL, 0) {
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 12,
+            margin_top = 12
+        };
+        donate_box.add (donate_label);
+        donate_box.add (donate_link);
+
         var secondary_box = new Gtk.Box (VERTICAL, 0);
         secondary_box.add (separator);
         secondary_box.add (calendar_info_bar);
         secondary_box.add (blocked_images_infobar);
         secondary_box.add (web_view);
+        secondary_box.add (donate_box);
 
         secondary_revealer = new Gtk.Revealer () {
             transition_type = SLIDE_UP
@@ -359,6 +372,8 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
                 avatar.set_loadable_icon (file_icon);
             });
         }
+
+        donate_link.activate_link.connect (ask_donate_message);
 
         /* Override default handler to stop event propagation. Otherwise clicking the menu will
            expand or collapse the MessageListItem. */
@@ -453,6 +468,73 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             print_error_dialog.show_error_details (e.message);
             print_error_dialog.present ();
             print_error_dialog.response.connect (() => print_error_dialog.destroy ());
+        }
+    }
+
+    private bool ask_donate_message () {
+        var dialog = new Granite.MessageDialog (
+            _("Donate message to elementary?"),
+            _("elementary staff will be able to read the contents of the message as well as your e-mail address."),
+            new ThemedIcon ("dialog-information")
+        );
+        var button = dialog.add_button (_("Donate"), Gtk.ResponseType.ACCEPT);
+        button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+        dialog.response.connect ((res) => {
+            if (res == Gtk.ResponseType.ACCEPT) {
+                donate_message.begin ();
+            }
+
+            dialog.destroy ();
+        });
+
+        dialog.present ();
+
+        return true; // Only to stop other handlers from being invoked for the LinkButton
+    }
+
+    private async void donate_message () {
+        var folder = message_info.summary.folder;
+        Camel.MimeMessage? donation_message = null;
+        try {
+            donation_message = yield folder.get_message (message_info.uid, GLib.Priority.DEFAULT, null);
+        } catch (Error e) {
+            MainWindow.send_error_message (
+                _("Failed to donate message"),
+                _("Could not get mime message."),
+                null,
+                e.message
+            );
+            return;
+        }
+
+        var from_address = Utils.get_sender_from_message (donation_message);
+        if (from_address == null) {
+            MainWindow.send_error_message (
+                _("Failed to donate message"),
+                _("No sender address found.")
+            );
+            return;
+        }
+
+        var from = new Camel.InternetAddress ();
+        from.unformat (from_address);
+        donation_message.set_from (from);
+
+        var to = new Camel.InternetAddress ();
+        to.unformat ("leolost@gmx.net");
+        donation_message.set_recipients (Camel.RECIPIENT_TYPE_TO, to);
+
+        try {
+            yield Backend.Session.get_default ().send_email (donation_message, from, to);
+            ((MainWindow) get_toplevel ()).send_info_toast (_("Message donated."));
+        } catch (Error e) {
+            MainWindow.send_error_message (
+                _("Failed to donate message"),
+                _("Could not send message."),
+                null,
+                e.message
+            );
         }
     }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -115,4 +115,27 @@ public class Mail.Utils {
 
         return "folder://%s/%s".printf (encoded_service_uid, encoded_normed_folder_name);
     }
+
+    public static string? get_sender_from_message (Camel.MimeMessage message) {
+        unowned Mail.Backend.Session session = Mail.Backend.Session.get_default ();
+        unowned var account_source_uid = message.get_source ();
+        var account_source = session.ref_source (account_source_uid);
+
+        if (account_source != null && account_source.has_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT)) {
+            unowned var account_extension = (E.SourceMailAccount) account_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+
+            var identity_uid = account_extension.identity_uid;
+            if (identity_uid != null && identity_uid != "") {
+                var identity_source = session.ref_source (identity_uid);
+
+                if (identity_source != null && identity_source.has_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY)) {
+                    unowned var identity_extension = (E.SourceMailIdentity) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY);
+
+                    return identity_extension.get_address ();
+                }
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
This would be very useful to investigate issues like #957 or #950 where normal forwarding doesn't work as that just takes the html and builds an entirely new message whereas this only modifies sender and recipient of the original message and sends it as is. For now it gets sent to a throwaway address of mine but it probably would be good to create an account (maybe even an elementary one?) that all contributors have access to (make credentials available in slack?) and change it to that before merging this. 
Any feedback regarding design, phrasing or whether this might be problematic in a way would be very appreciated! :)

Below every message:
![image](https://github.com/elementary/mail/assets/106322251/0e7b1339-c9be-4b73-8dfa-695a28c77218)

When the link is clicked:
![Screenshot from 2023-09-14 18 31 24](https://github.com/elementary/mail/assets/106322251/60f48bde-7f9c-40df-89e8-5c6d54876aa7)


Fixes #409 