### PR TITLE
AliasesDialog: screen reader fixes, design tweaks

### DIFF
--- a/src/Dialogs/AliasDialog/Alias.vala
+++ b/src/Dialogs/AliasDialog/Alias.vala
@@ -45,18 +45,16 @@ public class Mail.Alias : Gtk.ListBoxRow {
             xalign = 0
         };
 
-        var edit_name_label = new Gtk.Label (_("Name:")) {
-            halign = END
-        };
-
         var name_entry = new Gtk.Entry () {
+            margin_start = 12,
+            margin_end = 12,
             text = alias_name,
-            placeholder_text = _("Enter name…")
+            placeholder_text = _("John Doe")
         };
         name_entry.bind_property ("text", this, "alias-name", DEFAULT);
 
-        var edit_address_label = new Gtk.Label (_("Address:")) {
-            halign = END
+        var edit_name_label = new Granite.HeaderLabel (_("Name")) {
+            mnemonic_widget = name_entry
         };
 
         Regex? regex = null;
@@ -67,25 +65,29 @@ public class Mail.Alias : Gtk.ListBoxRow {
         }
 
         var address_entry = new Granite.ValidatedEntry.from_regex (regex) {
+            margin_start = 12,
+            margin_end = 12,
             text = address,
-            placeholder_text = _("Enter e-mail address…")
+            placeholder_text = _("Email@example.com")
         };
         address_entry.bind_property ("text", this, "address", BIDIRECTIONAL);
 
-        var delete_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic");
-
-        var edit_popover_content = new Gtk.Grid () {
-            margin_start = 6,
-            margin_end = 6,
-            margin_top = 6,
-            margin_bottom = 6,
-            column_spacing = 6,
-            row_spacing = 6
+        var edit_address_label = new Granite.HeaderLabel (_("E-mail Address")) {
+            mnemonic_widget = address_entry
         };
-        edit_popover_content.attach (edit_name_label, 0, 0);
-        edit_popover_content.attach (name_entry, 1, 0);
-        edit_popover_content.attach (edit_address_label, 0, 1);
-        edit_popover_content.attach (address_entry, 1, 1);
+
+        var delete_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic") {
+            tooltip_text = _("Delete alias")
+        };
+
+        var edit_popover_content = new Gtk.Box (VERTICAL, 6) {
+            margin_top = 6,
+            margin_bottom = 12
+        };
+        edit_popover_content.add (edit_name_label);
+        edit_popover_content.add (name_entry);
+        edit_popover_content.add (edit_address_label);
+        edit_popover_content.add (address_entry);
         edit_popover_content.show_all ();
 
         var edit_popover = new Gtk.Popover (null) {
@@ -94,7 +96,8 @@ public class Mail.Alias : Gtk.ListBoxRow {
 
         var edit_button = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("document-edit-symbolic", BUTTON),
-            popover = edit_popover
+            popover = edit_popover,
+            tooltip_text = _("Edit alias")
         };
 
         var box = new Gtk.Box (HORIZONTAL, 6) {
@@ -164,6 +167,7 @@ public class Mail.Alias : Gtk.ListBoxRow {
                 return Source.REMOVE;
             });
 
+            start_delete ();
             start_delete ();
         });
     }

--- a/src/Dialogs/AliasDialog/Alias.vala
+++ b/src/Dialogs/AliasDialog/Alias.vala
@@ -168,7 +168,6 @@ public class Mail.Alias : Gtk.ListBoxRow {
             });
 
             start_delete ();
-            start_delete ();
         });
     }
 

--- a/src/Dialogs/AliasDialog/AliasDialog.vala
+++ b/src/Dialogs/AliasDialog/AliasDialog.vala
@@ -106,7 +106,6 @@ public class Mail.AliasDialog : Granite.Dialog {
         default_width = 500;
         get_content_area ().add (overlay);
         this.add_button (_("Close"), Gtk.ResponseType.CLOSE);
-        present ();
 
         var identity_source = Backend.Session.get_default ().get_identity_source_for_account_uid (account_uid);
         var extension = (E.SourceMailIdentity) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY);

--- a/src/Dialogs/AliasDialog/AliasDialog.vala
+++ b/src/Dialogs/AliasDialog/AliasDialog.vala
@@ -17,7 +17,7 @@
 * Authored by: Leonhard Kargl <leo.kargl@proton.me>
 */
 
-public class Mail.AliasDialog : Hdy.ApplicationWindow {
+public class Mail.AliasDialog : Granite.Dialog {
     public string account_uid { get; construct; }
 
     private HashTable<string, string?> aliases;
@@ -30,12 +30,6 @@ public class Mail.AliasDialog : Hdy.ApplicationWindow {
     }
 
     construct {
-        var header = new Hdy.HeaderBar () {
-            show_close_button = true
-        };
-        header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        header.get_style_context ().add_class ("default-decoration");
-
         var placeholder_title = new Gtk.Label (_("No Aliases")) {
             xalign = 0
         };
@@ -70,16 +64,19 @@ public class Mail.AliasDialog : Hdy.ApplicationWindow {
             hscrollbar_policy = NEVER
         };
 
+        var add_button_label = new Gtk.Label (_("Add Alias…"));
+
         var add_box = new Gtk.Box (HORIZONTAL, 0);
         add_box.add (new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR));
-        add_box.add (new Gtk.Label (_("Add Alias…")));
+        add_box.add (add_button_label);
 
         var add_button = new Gtk.Button () {
             child = add_box,
-            margin_top = 2,
-            margin_bottom = 2
+            margin_top = 3,
+            margin_bottom = 3
         };
         add_button.get_style_context ().add_class ("image-button");
+        add_button_label.mnemonic_widget = add_button;
 
         var actionbar = new Gtk.ActionBar ();
         actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
@@ -92,27 +89,23 @@ public class Mail.AliasDialog : Hdy.ApplicationWindow {
         var frame = new Gtk.Frame (null) {
             margin_start = 12,
             margin_end = 12,
-            margin_bottom = 12,
             child = content_box
         };
-
-        var box = new Gtk.Box (VERTICAL, 0);
-        box.add (header);
-        box.add (frame);
 
         toast = new Granite.Widgets.Toast ("");
         toast.set_default_action (_("Undo"));
 
         var overlay = new Gtk.Overlay () {
-            child = box
+            child = frame
         };
         overlay.add_overlay (toast);
+        overlay.show_all ();
 
         title = _("Aliases");
         default_height = 300;
         default_width = 500;
-        add (overlay);
-        show_all ();
+        get_content_area ().add (overlay);
+        this.add_button (_("Close"), Gtk.ResponseType.CLOSE);
         present ();
 
         var identity_source = Backend.Session.get_default ().get_identity_source_for_account_uid (account_uid);
@@ -132,6 +125,8 @@ public class Mail.AliasDialog : Hdy.ApplicationWindow {
 
             list.invalidate_filter ();
         });
+
+        response.connect (destroy);
 
         delete_event.connect (() => {
             foreach (var child in list.get_children ()) {

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -152,7 +152,11 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem, Mail.Sourc
         var menu = new Gtk.Menu ();
 
         var alias_item = new Gtk.MenuItem.with_label (_("Edit Aliases…"));
-        alias_item.activate.connect (() => new AliasDialog (account.service.uid));
+        alias_item.activate.connect (() => {
+            new AliasDialog (account.service.uid) {
+                transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window
+            };
+        });
         menu.add (alias_item);
 
         menu.show_all ();

--- a/src/FoldersView/AccountSourceItem.vala
+++ b/src/FoldersView/AccountSourceItem.vala
@@ -155,7 +155,7 @@ public class Mail.AccountSourceItem : Mail.SourceList.ExpandableItem, Mail.Sourc
         alias_item.activate.connect (() => {
             new AliasDialog (account.service.uid) {
                 transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window
-            };
+            }.present ();
         });
         menu.add (alias_item);
 


### PR DESCRIPTION
Alias:
* Use a vertical form layout with header labels to match the design of other forms
* Make sure the screen reader knows how to describe entries by setting mnemonic_widget
* Placeholder text in forms should contain example content, not explanation text or directions
* Image buttons should have tooltip text (screenreader reads this too)

AliasDialog:
* Subclass Granite.Dialog since we're not doing anything that requires a Hdy.Window
* Dialogs should have a transient parent so they are centered on the parent etc
* Make sure screen reader can read the add button
* Use built-in method for dialog buttons instead of adding window controls manually