### PR TITLE
Fix webview scroll

### DIFF
--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -143,7 +143,7 @@ public class Mail.MessageList : Gtk.Box {
         vpaned = new Gtk.Paned (Gtk.Orientation.VERTICAL);
         var scrolled_window = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = NEVER,
-            min_content_height = 150
+            min_content_height = 200
         };
         scrolled_window.add (list_box);
 
@@ -152,7 +152,8 @@ public class Mail.MessageList : Gtk.Box {
             margin_bottom = 12,
             margin_start = 12,
             margin_end = 12,
-            shadow_type = Gtk.ShadowType.ETCHED_IN
+            shadow_type = Gtk.ShadowType.ETCHED_IN,
+            no_show_all = true
         };
 
         vpaned.pack1 (scrolled_window, false, false);
@@ -168,7 +169,10 @@ public class Mail.MessageList : Gtk.Box {
     public void row_expand_changed (Mail.MessageListItem row) {
         if (view_widget != null) {
             web_view_frame.remove (view_widget);
+            view_widget = null;
         }
+
+        web_view_frame.hide ();
 
         if (row.expanded) {
             var index = 0;
@@ -184,6 +188,7 @@ public class Mail.MessageList : Gtk.Box {
             view_widget = row.web_view;
             web_view_frame.add (view_widget);
             row.web_view.show_all ();
+            web_view_frame.show ();
         }
     }
 

--- a/src/MessageList/MessageList.vala
+++ b/src/MessageList/MessageList.vala
@@ -143,8 +143,9 @@ public class Mail.MessageList : Gtk.Box {
         vpaned = new Gtk.Paned (Gtk.Orientation.VERTICAL);
         var scrolled_window = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = NEVER,
-            min_content_height = 200
+            min_content_height = 120
         };
+
         scrolled_window.add (list_box);
 
         web_view_frame = new Gtk.Frame ("") {
@@ -229,7 +230,7 @@ public class Mail.MessageList : Gtk.Box {
         var children = list_box.get_children ();
         var num_children = children.length ();
         if (num_children > 0) {
-            var child = list_box.get_row_at_index ((int) num_children - 1);
+            var child = list_box.get_row_at_index (0);
             if (child != null && child is MessageListItem) {
                 var list_item = (MessageListItem) child;
                 list_item.expanded = true;
@@ -324,6 +325,6 @@ public class Mail.MessageList : Gtk.Box {
             timestamp2 = message2.message_info.date_sent;
         }
 
-        return (int)(timestamp1 - timestamp2);
+        return (int)(timestamp2 - timestamp1);
     }
 }

--- a/src/MessageList/MessageListItem.vala
+++ b/src/MessageList/MessageListItem.vala
@@ -23,7 +23,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
     public Camel.MessageInfo message_info { get; construct; }
     public Camel.MimeMessage? mime_message { get; private set; default = null; }
 
-    private Mail.WebView web_view;
+    public Mail.WebView web_view { get; private set; }
     private GLib.Cancellable loading_cancellable;
 
     private Gtk.InfoBar calendar_info_bar;
@@ -58,18 +58,22 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
             } else {
                 style_context.add_class ("collapsed");
             }
+
+            message_list.row_expand_changed (this);
         }
     }
 
     private GLib.Settings settings;
+    public unowned Mail.MessageList message_list { get; construct; }
 
-    public MessageListItem (Camel.MessageInfo message_info) {
+    public MessageListItem (Camel.MessageInfo message_info, Mail.MessageList message_list) {
         Object (
             margin_top: 12,
             margin_bottom: 12,
             margin_start: 12,
             margin_end: 12,
-            message_info: message_info
+            message_info: message_info,
+            message_list: message_list
         );
     }
 
@@ -304,11 +308,7 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         ((Gtk.Box) blocked_images_infobar.get_action_area ()).orientation = Gtk.Orientation.VERTICAL;
 
         web_view = new Mail.WebView () {
-            margin_top = 12,
-            margin_bottom = 12,
-            margin_start = 12,
-            margin_end = 12,
-            bind_height_to_page_height = true
+            bind_height_to_page_height = false
         };
         web_view.mouse_target_changed.connect (on_mouse_target_changed);
         web_view.context_menu.connect (on_webview_context_menu);
@@ -320,7 +320,6 @@ public class Mail.MessageListItem : Gtk.ListBoxRow {
         secondary_box.add (separator);
         secondary_box.add (calendar_info_bar);
         secondary_box.add (blocked_images_infobar);
-        secondary_box.add (web_view);
 
         secondary_revealer = new Gtk.Revealer () {
             transition_type = SLIDE_UP


### PR DESCRIPTION
Fixes #950 

The currently used version of WebView does not interact properly with Gtk's size allocation when buried inside a scrolled window inside a revealer inside a listbox ... 

The only solution I could find was to not show the webview within the list box but to show it in a separate pane of of a Gtk.Paned so that the native scrolling ability of WebView is used.  Clearly, this changes the UI significantly so may not be acceptable but at least the message contents of long messages are always visible.

![Screenshot from 2024-01-22 12 21 19](https://github.com/elementary/mail/assets/10513844/7cebf545-cfe4-4c51-9dfd-f3234f54407d)

Image shows a thread with 4 messages.  The most recent message header is shown expanded, the rest are below it in a scrolled window (i.e. reversed order compared to master).  This is because of problems controlling where the divider of the vertical pane is placed automatically.


