### PR TITLE
Add apparmor profile

### DIFF
--- a/data/io.elementary.mail.apparmor
+++ b/data/io.elementary.mail.apparmor
@@ -1,0 +1,9 @@
+abi <abi/4.0>,
+include <tunables/global>
+
+profile io.elementary.mail /usr/bin/io.elementary.mail flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/io.elementary.mail>
+}

--- a/data/meson.build
+++ b/data/meson.build
@@ -18,6 +18,12 @@ install_data(
     install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 )
 
+install_data(
+    meson.project_name() + '.apparmor',
+    install_dir: join_paths(get_option('sysconfdir'), 'apparmor.d'),
+    rename: meson.project_name()
+)
+
 i18n.merge_file (
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',


### PR DESCRIPTION
On OS 8 mail crashes by default with these errors when opening an html message:
```
bwrap: Creating new namespace failed: Permission denied

** (io.elementary.mail:8681): ERROR **: 20:09:48.735: Failed to fully launch dbus-proxy: Child process exited with code 1
```

This seems to be caused by changes in how ubuntu configures bubblewrap with apps now requiring apparmor profiles to access it ?
I'm not really sure what's actually going on behind the scenes but as per [this launchpad bug](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2046844) and my own testing creating an apparmor profile for mail fixes the issue.