### PR TITLE
Force disabling webkit compositing mode

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -234,6 +234,7 @@ public class Mail.Application : Gtk.Application {
 }
 
 public static int main (string[] args) {
+    GLib.Environment.set_variable ("WEBKIT_DISABLE_COMPOSITING_MODE", "1", true);
     var application = new Mail.Application ();
     return application.run (args);
 }


### PR DESCRIPTION
This fixes #950 which currently renders mail pretty much unusable and is an alternative to #973 that doesn't change the current design. I think it might be worth considering merging and releasing this or at least something similar to #973 since OS8 is still a bit away and in my testing it's not even yet fixed there (neither GTK3 nor GTK4) although some bug reports from webkit suggest it is :shrug: 

As per [webkit documentation](https://trac.webkit.org/wiki/EnvironmentVariables) this

> Force[s] Accelerated Compositing mode to be always off 

While this is of course not an optimal solution I think it should be fine for the mail messages usecase.