### PR TITLE
Alias: Do not translate placeholder email address

### DIFF
--- a/src/Dialogs/AliasDialog/Alias.vala
+++ b/src/Dialogs/AliasDialog/Alias.vala
@@ -68,7 +68,7 @@ public class Mail.Alias : Gtk.ListBoxRow {
             margin_start = 12,
             margin_end = 12,
             text = address,
-            placeholder_text = _("Email@example.com")
+            placeholder_text = "email@example.com"
         };
         address_entry.bind_property ("text", this, "address", BIDIRECTIONAL);
 


### PR DESCRIPTION
I don't think we need to make email addresses translatable. Also use uncapitalized one because it's more common