### PR TITLE
Flatpak: Use libportal from Platform

### DIFF
--- a/io.elementary.mail.json
+++ b/io.elementary.mail.json
@@ -114,21 +114,6 @@
             ]
         },
         {
-            "name": "libportal",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Ddocs=false",
-                "-Dbackends=['gtk3']"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal.git",
-                    "tag": "0.6"
-                }
-            ]
-        },
-        {
             "name": "mail",
             "buildsystem": "meson",
             "sources": [


### PR DESCRIPTION
libportal is bundled from Platform 8 so we shouldn't need it here anymore