### PR TITLE
FolderItemModel: cleanup

### DIFF
--- a/src/FolderList/AccountItemModel.vala
+++ b/src/FolderList/AccountItemModel.vala
@@ -68,7 +68,7 @@ public class Mail.AccountItemModel : Mail.SourceList.ExpandableItem, Mail.Source
     private void folder_renamed (string old_name, Camel.FolderInfo folder_info) {
         FolderItemModel item;
         folder_items.unset (old_name, out item);
-        item.update_infos (folder_info);
+        item.folder_info = folder_info;
         folder_items[item.full_name] = item;
     }
 
@@ -101,7 +101,7 @@ public class Mail.AccountItemModel : Mail.SourceList.ExpandableItem, Mail.Source
         foreach (var folder_item in folder_items.values) {
             try {
                 var folder_info = yield offlinestore.get_folder_info (folder_item.full_name, 0, GLib.Priority.DEFAULT, connect_cancellable);
-                folder_item.update_infos (folder_info);
+                folder_item.folder_info = folder_info;
             } catch (Error e) {
                 // We can cancel the operation
                 if (!(e is GLib.IOError.CANCELLED)) {
@@ -115,6 +115,7 @@ public class Mail.AccountItemModel : Mail.SourceList.ExpandableItem, Mail.Source
         var folderinfo = _folderinfo;
         while (folderinfo != null) {
             var folder_item = new FolderItemModel (account, folderinfo);
+
             saved_state.bind_with_expandable_item (folder_item);
             folder_items[folderinfo.full_name] = folder_item;
             folder_item.start_edit.connect (() => start_edit (folder_item));

--- a/src/FolderList/FolderItemModel.vala
+++ b/src/FolderList/FolderItemModel.vala
@@ -15,7 +15,7 @@ public class Mail.FolderItemModel : Mail.SourceList.ExpandableItem {
         get {
             return _folder_info;
         }
-        set {
+        construct set {
             _folder_info = value;
             update_infos ();
         }

--- a/src/FolderList/FolderItemModel.vala
+++ b/src/FolderList/FolderItemModel.vala
@@ -1,21 +1,6 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
-/*-
- * Copyright (c) 2017 elementary LLC. (https://elementary.io)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+/*
+ * SPDX-License-Identifier: :GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2017-2026 elementary, Inc. (https://elementary.io)
  *
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
@@ -23,19 +8,31 @@
 public class Mail.FolderItemModel : Mail.SourceList.ExpandableItem {
     public signal void start_edit ();
 
-    public Camel.FolderInfo folder_info { get; private set; }
+    public Backend.Account account { get; construct; }
+
+    private Camel.FolderInfo _folder_info;
+    public Camel.FolderInfo folder_info {
+        get {
+            return _folder_info;
+        }
+        set {
+            _folder_info = value;
+            update_infos ();
+        }
+    }
+
     public string full_name { get; private set; }
     public bool is_special_folder { get; private set; default = true; }
     public int pos { get; private set; }
-    public Backend.Account account { get; construct; }
 
-    private bool can_modify = true;
     private Cancellable cancellable;
     private string old_name;
 
-    public FolderItemModel (Backend.Account account, Camel.FolderInfo folderinfo) {
-        Object (account: account);
-        update_infos (folderinfo);
+    public FolderItemModel (Backend.Account account, Camel.FolderInfo folder_info) {
+        Object (
+            account: account,
+            folder_info: folder_info
+        );
     }
 
     construct {
@@ -65,57 +62,47 @@ public class Mail.FolderItemModel : Mail.SourceList.ExpandableItem {
         return menu;
     }
 
-    public void update_infos (Camel.FolderInfo folderinfo) {
-        folder_info = folderinfo;
-
-        name = old_name = folderinfo.display_name;
-        full_name = folderinfo.full_name;
-        if (folderinfo.unread > 0) {
-            badge = "%d".printf (folderinfo.unread);
+    private void update_infos () {
+        name = old_name = folder_info.display_name;
+        full_name = folder_info.full_name;
+        if (folder_info.unread > 0) {
+            badge = "%d".printf (folder_info.unread);
         }
 
-        var full_folder_info_flags = Utils.get_full_folder_info_flags (account.service, folderinfo);
+        var full_folder_info_flags = Utils.get_full_folder_info_flags (account.service, folder_info);
         switch (full_folder_info_flags & Camel.FOLDER_TYPE_MASK) {
             case Camel.FolderInfoFlags.TYPE_INBOX:
                 icon = new ThemedIcon ("mail-inbox");
-                can_modify = false;
                 pos = 1;
                 break;
             case Camel.FolderInfoFlags.TYPE_DRAFTS:
                 icon = new ThemedIcon ("mail-drafts");
-                can_modify = false;
                 pos = 2;
                 break;
             case Camel.FolderInfoFlags.TYPE_OUTBOX:
                 icon = new ThemedIcon ("mail-outbox");
-                can_modify = false;
                 pos = 3;
                 break;
             case Camel.FolderInfoFlags.TYPE_SENT:
                 icon = new ThemedIcon ("mail-sent");
-                can_modify = false;
                 pos = 4;
                 break;
             case Camel.FolderInfoFlags.TYPE_ARCHIVE:
                 icon = new ThemedIcon ("mail-archive");
-                can_modify = false;
                 pos = 5;
                 badge = null;
                 break;
             case Camel.FolderInfoFlags.TYPE_TRASH:
-                icon = new ThemedIcon (folderinfo.total == 0 ? "user-trash" : "user-trash-full");
-                can_modify = false;
+                icon = new ThemedIcon (folder_info.total == 0 ? "user-trash" : "user-trash-full");
                 pos = 6;
                 badge = null;
                 break;
             case Camel.FolderInfoFlags.TYPE_JUNK:
                 icon = new ThemedIcon ("edit-flag");
-                can_modify = false;
                 pos = 7;
                 break;
             default:
                 icon = new ThemedIcon ("folder");
-                can_modify = true;
                 pos = 8;
                 is_special_folder = false;
                 break;

--- a/src/FolderList/FolderItemModel.vala
+++ b/src/FolderList/FolderItemModel.vala
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: :GPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  * SPDX-FileCopyrightText: 2017-2026 elementary, Inc. (https://elementary.io)
  *
  * Authored by: Corentin Noël <corentin@elementary.io>


### PR DESCRIPTION
* SPDX header
* GObject-style construction
* make `folder_info` public set so that we don't have multiple API entry points for the same property
* remove unused `can_modify`