### PR TITLE
folks: Use build-options instead of config-opts to force libdir

### DIFF
--- a/io.elementary.mail.json
+++ b/io.elementary.mail.json
@@ -103,9 +103,11 @@
                 "-Dofono_backend=false",
                 "-Dtelepathy_backend=false",
                 "-Dimport_tool=false",
-                "-Dinspect_tool=false",
-                "-Dlibdir=/app/lib"
+                "-Dinspect_tool=false"
             ],
+            "build-options": {
+                "libdir": "/app/lib"
+            },
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
Fixes the following build error:

```
ERROR: Got argument libdir as both -Dlibdir and --libdir. Pick one.
```

https://github.com/elementary/mail/actions/runs/30384177839/job/90359180538