### PR TITLE
Fix rename folder does not work 

### DIFF
--- a/src/FolderList/FolderItemModel.vala
+++ b/src/FolderList/FolderItemModel.vala
@@ -157,14 +157,14 @@ public class Mail.FolderItemModel : Mail.SourceList.ExpandableItem {
 
         var offlinestore = (Camel.Store)account.service;
 
-        Camel.FolderInfo? folder_info = null;
+        Camel.FolderInfo? new_folder_info = null;
         try {
-            folder_info = yield offlinestore.get_folder_info (new_full_name, FAST, GLib.Priority.DEFAULT, cancellable);
+            new_folder_info = yield offlinestore.get_folder_info (new_full_name, FAST, GLib.Priority.DEFAULT, cancellable);
         } catch (Error e) {
             warning (e.message);
         }
 
-        if (null != folder_info) {
+        if (new_folder_info != null) {
             if (name == old_name) {
                 notify["name"].connect (cancel_rename);
             } else {

--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -416,10 +416,6 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
             base (name);
         }
 
-        construct {
-            editable = false;
-        }
-
         /**
          * Adds an item.
          *

--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -1048,6 +1048,7 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
 
         private Item? selected;
         private unowned Item? edited;
+        private Item? activated;
 
         private Gtk.Entry? editable_entry;
         private Gtk.CellRendererText text_cell;
@@ -1620,8 +1621,11 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
                             && item.selectable
                             && over_cell (column, path, text_cell, cell_x)
                         ) {
+                            // Keep back reference of item so that it can be accessed in Idle.add_once()
+                            // where item is already freed
+                            activated = item;
                             // Start editing after native event handlers finished else fails
-                            Idle.add_once (() => { start_editing_item (item); });
+                            Idle.add_once (() => { start_editing_item (activated); });
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1071
Can be rebase-merged if desired.

## Changes Summary
### 1.  ExpandableItem: Do not overwrite editable which already set
Fixes the constructor of `ExpandableItem` class overwrites `editable` which contains value set in `update_infos()` of `FolderItemModel` class.

<details>

<summary>How to validate this fix</summary>

Try adding the following debug codes against latest master:

```diff
diff --git a/src/FolderList/FolderItemModel.vala b/src/FolderList/FolderItemModel.vala
index 0d765e25..d734e6bb 100644
--- a/src/FolderList/FolderItemModel.vala
+++ b/src/FolderList/FolderItemModel.vala
@@ -113,6 +113,8 @@ public class Mail.FolderItemModel : Mail.SourceList.ExpandableItem {
             editable = false;
             edited.disconnect (rename);
         }
+
+        warning ("FolderItemModel name=%s, editable=%s", name, editable.to_string ());
     }
 
     private async void refresh () {
diff --git a/src/SourceList/SourceList.vala b/src/SourceList/SourceList.vala
index c758f662..80322bff 100644
--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -418,6 +418,8 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
 
         construct {
             editable = false;
+
+            warning ("ExpandableItem name=%s, editable=%s", name, editable.to_string ());
         }
 
         /**
```

You can see `editable` flags of non-special folders are overwritten from true to false:

```
** (io.elementary.mail:6793): WARNING **: 22:56:19.036: FolderItemModel.vala:117: FolderItemModel name=Inbox, editable=false

** (io.elementary.mail:6793): WARNING **: 22:56:19.036: SourceList.vala:422: ExpandableItem name=Inbox, editable=false

** (io.elementary.mail:6793): WARNING **: 22:56:19.036: FolderItemModel.vala:117: FolderItemModel name=[Gmail], editable=true

** (io.elementary.mail:6793): WARNING **: 22:56:19.036: SourceList.vala:422: ExpandableItem name=[Gmail], editable=false
```

</details>

### 2. SourceList: Fix double-click does not trigger rename
Fixes the following warning is shown when double-clicking the source list:

```
** (io.elementary.mail:9075): CRITICAL **: 23:15:29.989: mail_source_list_tree_start_editing_item: assertion 'item != NULL' failed
```

This is because `item` is already freed when the callback of `Idle.add_once()` is called because `on_button_pressed()` is already returned.

### 3. FolderItemModel: Fix coredump when deciding new name
Mails coredumps when finishing rename with the following place:

```
Thread 1 "io.elementary.m" received signal SIGSEGV, Segmentation fault.
mail_folder_item_model_rename_co (_data_=0x5baf932ed1d0) at ../src/FolderList/FolderItemModel.vala:184
184             yield offlinestore.rename_folder (folder_info.full_name, new_full_name, GLib.Priority.DEFAULT, cancellable);
```

This is because `folder_info` points to null when the new name is not yet taken when `offlinestore.folder_info()` is called just before here. So, rename `folder_info` to `new_folder_info` so that `folder_info` as a property of `FolderItemModel` class is not sealed unintentionally.

### Checklist
- [x] Confirmed folders can be renamed with F2, double-clicking, and the context menu
- [x] Confirmed the new folder name renamed in Mails is reflected to the server (I used Evolution to confirm this)

https://github.com/user-attachments/assets/ffd40ad1-992c-4495-bd9e-7d0a82cc47f8
