### PR TITLE
Construct image label button for GTK4

### DIFF
--- a/src/Composer.vala
+++ b/src/Composer.vala
@@ -243,12 +243,14 @@ public class Mail.Composer : Hdy.ApplicationWindow {
             tooltip_text = _("Insert Signature…")
         };
 
-        var send = new Gtk.Button.from_icon_name ("mail-send-symbolic", Gtk.IconSize.MENU) {
+        var send_buttonbox = new Gtk.Box (HORIZONTAL, 0);
+        send_buttonbox.add (new Gtk.Image.from_icon_name ("mail-send-symbolic", MENU));
+        send_buttonbox.add (new Gtk.Label (_("Send")));
+
+        var send = new Gtk.Button () {
             action_name = ACTION_PREFIX + ACTION_SEND,
-            always_show_image = true,
-            label = _("Send"),
+            child = send_buttonbox,
             margin_top = 6,
-            margin_end = 0,
             margin_bottom = 6,
             margin_start = 6,
             sensitive = false,

--- a/src/Dialogs/SignatureDialog/SignatureDialog.vala
+++ b/src/Dialogs/SignatureDialog/SignatureDialog.vala
@@ -127,13 +127,14 @@ public class Mail.SignatureDialog : Hdy.ApplicationWindow {
 
         var default_menu = new Menu ();
 
+        var default_buttonbox = new Gtk.Box (HORIZONTAL, 0);
+        default_buttonbox.add (new Gtk.Label (_("Set Default For…")));
+        default_buttonbox.add (new Gtk.Image.from_icon_name ("pan-down-symbolic", SMALL_TOOLBAR));
+
         var default_menubutton = new Gtk.MenuButton () {
-            always_show_image = true,
+            child = default_buttonbox,
             halign = END,
-            image = new Gtk.Image.from_icon_name ("pan-down-symbolic", SMALL_TOOLBAR),
-            image_position = RIGHT,
             menu_model = default_menu,
-            label = _("Set Default For…"),
             use_popover = false,
             direction = UP,
             sensitive = false


### PR DESCRIPTION
can be rebased merged

GTK4 prep. `always_show_image` and `image_position` don't exist in GTK4.