### PR TITLE
SignatureDialog: use Box.add not pack

### DIFF
--- a/src/Dialogs/SignatureDialog/SignatureDialog.vala
+++ b/src/Dialogs/SignatureDialog/SignatureDialog.vala
@@ -134,6 +134,7 @@ public class Mail.SignatureDialog : Hdy.ApplicationWindow {
         var default_menubutton = new Gtk.MenuButton () {
             child = default_buttonbox,
             halign = END,
+            hexpand = true,
             menu_model = default_menu,
             use_popover = false,
             direction = UP,
@@ -143,8 +144,8 @@ public class Mail.SignatureDialog : Hdy.ApplicationWindow {
         var end_actionbar = new Gtk.Box (HORIZONTAL, 12) {
             margin_top = 12
         };
-        end_actionbar.pack_start (delete_button);
-        end_actionbar.pack_end (default_menubutton);
+        end_actionbar.add (delete_button);
+        end_actionbar.add (default_menubutton);
 
         var content_box = new Gtk.Box (VERTICAL, 0) {
             margin_start = 12,


### PR DESCRIPTION
Can't use pack_start or pack_end with GTK4