### PR TITLE
SourceList: don't subclass SourceList

### DIFF
--- a/src/FolderList/FolderList.vala
+++ b/src/FolderList/FolderList.vala
@@ -48,7 +48,8 @@ public class Mail.FolderList : Gtk.Box {
         source_list.root.add (session_source_item);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null) {
-            child = source_list
+            child = source_list,
+            hscrollbar_policy = NEVER
         };
 
         var dialogs_section = new Menu ();

--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -99,7 +99,7 @@
  * @since 0.2
  * @see Gtk.Paned
  */
-public class Mail.SourceList : Gtk.ScrolledWindow {
+public class Mail.SourceList : Gtk.Bin {
 
     /**
      * = WORKING INTERNALS =
@@ -1886,8 +1886,6 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
 
     construct {
         tree = new Tree (data_model);
-
-        set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
         child = tree;
 
         tree.item_selected.connect ((item) => item_selected (item));


### PR DESCRIPTION
Can't subclass ScrolledWindow in GTK4. And we actually already have a ScrolledWindow anyways