### PR TITLE
SourceList: don't subclass sealed Gtk.CellRendererPixbuf

### DIFF
--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -1072,7 +1072,7 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
             text_cell.editing_started.connect (on_editing_started);
             text_cell.editing_canceled.connect (on_editing_canceled);
 
-            icon_cell = new Gtk.CellRendererPixbuf() {
+            icon_cell = new Gtk.CellRendererPixbuf () {
                 mode = ACTIVATABLE
             };
 

--- a/src/SourceList/SourceList.vala
+++ b/src/SourceList/SourceList.vala
@@ -953,30 +953,6 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
     }
 
     /**
-     * Class responsible for rendering Item.icon and Item.activatable. It also
-     * notifies about clicks through the activated() signal.
-     */
-    private class CellRendererIcon : Gtk.CellRendererPixbuf {
-        public signal void activated (string path);
-
-        construct {
-            mode = Gtk.CellRendererMode.ACTIVATABLE;
-        }
-
-        public override bool activate (
-            Gdk.Event event,
-            Gtk.Widget widget,
-            string path,
-            Gdk.Rectangle background_area,
-            Gdk.Rectangle cell_area,
-            Gtk.CellRendererState flags
-        ) {
-            activated (path);
-            return true;
-        }
-    }
-
-    /**
      * A cell renderer that only adds space.
      */
     private class CellRendererSpacer : Gtk.CellRenderer {
@@ -1052,7 +1028,7 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
         private Gtk.CellRendererText text_cell;
         private Gtk.EventControllerKey key_controller;
         private Gtk.GestureMultiPress button_controller;
-        private CellRendererIcon icon_cell;
+        private Gtk.CellRendererPixbuf icon_cell;
         private CellRendererBadge badge_cell;
         private CellRendererExpander primary_expander_cell;
         private CellRendererExpander secondary_expander_cell;
@@ -1096,7 +1072,9 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
             text_cell.editing_started.connect (on_editing_started);
             text_cell.editing_canceled.connect (on_editing_canceled);
 
-            icon_cell = new CellRendererIcon ();
+            icon_cell = new Gtk.CellRendererPixbuf() {
+                mode = ACTIVATABLE
+            };
 
             // First expander. Used for normal expandable items
             primary_expander_cell = new CellRendererExpander () {
@@ -1731,7 +1709,7 @@ public class Mail.SourceList : Gtk.ScrolledWindow {
             Gtk.CellRenderer renderer,
             Gtk.TreeModel model, Gtk.TreeIter iter
         ) {
-            var icon_renderer = renderer as CellRendererIcon;
+            var icon_renderer = renderer as Gtk.CellRendererPixbuf;
             assert (icon_renderer != null);
 
             bool visible = false;


### PR DESCRIPTION
This class is sealed in Gtk4. activated is unused